### PR TITLE
Add gyroscope toggle feature

### DIFF
--- a/input/SdlDriver.cpp
+++ b/input/SdlDriver.cpp
@@ -48,6 +48,15 @@ DWORD SdlDriver::injectionloop() {
     AxisReport sdl_axisreport;
     //IMU_STATE jsl_imu_secondary;
 
+    bool gyro_is_disabled[ALLPLAYERS];
+    std::chrono::time_point<std::chrono::steady_clock> disable_last_pressed[ALLPLAYERS];
+
+
+    for(int x = PLAYER1; x < ALLPLAYERS; x++) {
+        gyro_is_disabled[x] = false;
+        disable_last_pressed[x] = std::chrono::steady_clock::now();
+    }
+
     auto time_current = std::chrono::steady_clock::now();
     auto time_previous = time_current;
 
@@ -107,6 +116,14 @@ DWORD SdlDriver::injectionloop() {
                 }
             }
 
+            std::chrono::duration<float> gyro_timeout_duration = time_current - disable_last_pressed[player];
+            if(gyro_timeout_duration.count() > 0.25f) {
+                if (sdl_buttons & profile.BUTTONPRIM[TOGGLEGYRO]) {
+                    // toggle the disabled state.
+                    gyro_is_disabled[player] = !gyro_is_disabled[player];
+                }
+            }
+
 
             dev->AIMSTICK.x = sdl_axisreport.RStick.x;
             dev->AIMSTICK.y = sdl_axisreport.RStick.y;
@@ -117,8 +134,16 @@ DWORD SdlDriver::injectionloop() {
             if(sdl_axisreport.RTrigger >= 0.50)
                 sdl_buttons |= 1 << GAMEPAD_OFFSET_TRIGGER_RIGHT;
 
-            dev->GYRO.x = -sdl_motionreport.GyroY;
-            dev->GYRO.y = -sdl_motionreport.GyroX;
+
+            // Disable the gyro if the toggle is off.
+            if(!gyro_is_disabled[player]) {
+                dev->GYRO.x = -sdl_motionreport.GyroY;
+                dev->GYRO.y = -sdl_motionreport.GyroX;
+            }
+            else {
+                dev->GYRO.x = 0;
+                dev->GYRO.y = 0;
+            }
 
             for(int button = FIRE; button < TOTALBUTTONS; button++) {
                 dev->BUTTONPRIM[button] = (sdl_buttons & profile.BUTTONPRIM[button]) != 0;

--- a/input/SdlDriver.cpp
+++ b/input/SdlDriver.cpp
@@ -117,10 +117,11 @@ DWORD SdlDriver::injectionloop() {
             }
 
             std::chrono::duration<float> gyro_timeout_duration = time_current - disable_last_pressed[player];
-            if(gyro_timeout_duration.count() > 0.25f) {
+            if(gyro_timeout_duration.count() > 0.5f) {
                 if (sdl_buttons & profile.BUTTONPRIM[TOGGLEGYRO]) {
                     // toggle the disabled state.
                     gyro_is_disabled[player] = !gyro_is_disabled[player];
+                    disable_last_pressed[player] = time_current;
                 }
             }
 


### PR DESCRIPTION
This fixes the Gyroscope Toggle button by actually implementing it.

Binding and pressing the gyroscope toggle button will allow the player to turn their gyroscope on and off. This button has a half-second delay between activation to make the gyroscope state change definite. 