### PR TITLE
Player Space, Seperate Gyro Sensitivities, Analog Trigger Thresholds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,11 +71,12 @@ add_library(SDL2_GyroInjector SHARED
         1964_plugin.cpp
         1964_plugin.h
         common/vec2.h
+        common/vec3.h
         ui/ConfigDialog.cpp
         ui/ConfigDialog.h
         ui/1964_config.ui
-        input/InputClasses.h
-        input/InputClasses.cpp
+        input/SDLDevice.h
+        input/SDLDevice.cpp
         input/GamepadMotion/GamepadMotion.hpp
         input/GamepadMotion/GamepadMotion.cpp
         common/common.cpp)

--- a/common/Helpers.cpp
+++ b/common/Helpers.cpp
@@ -37,3 +37,4 @@ int PluginHelpers::ClampInt(const int value, const int min, const int max)
     const int test = value < min ? min : value;
     return test > max ? max : test;
 }
+

--- a/common/Helpers.h
+++ b/common/Helpers.h
@@ -36,6 +36,12 @@ class PluginHelpers {
     public:
         static float ClampFloat(float value, float min, float max);
         static int ClampInt(int value, int min, int max);
+
+    // https://stackoverflow.com/questions/1903954/is-there-a-standard-sign-function-signum-sgn-in-c-c/10133700
+
+    template <typename T> static int sign(T val) {
+            return (val > T(0)) - (val < T(0));
+        }
 };
 
 #endif //INC_1964_INPUT_JOYSHOCKCPP_HELPERS_H

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -23,7 +23,8 @@ using namespace js_settings;
     void js_settings::from_json(const nlohmann::json &j, PROFILE &p) {
         p.StickMode = j.value("stickmode", FULLSTICK);
         p.DS4Color = j.value("ds4color", 0);
-        j.at("gyroscopesensitivity").at("x").get_to(p.GyroscopeSensitivity.x);
+        //j.at("gyroscopesensitivity").at("x").get_to(p.GyroscopeSensitivity.x);
+        p.AimStickSensitivity.x = j.at("gyroscopesensitivity").value("x", 1.0f);
         j.at("gyroscopesensitivity").at("y").get_to(p.AimStickSensitivity.y);
         j.at("aimsticksensitivity").at("x").get_to(p.AimStickSensitivity.x);
         j.at("aimsticksensitivity").at("y").get_to(p.AimStickSensitivity.y);

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -43,6 +43,11 @@ using namespace js_settings;
         j.at("aimstick").get_to(p.AimStick);
         j.at("gyrospace").get_to(p.GyroscopeSpace);
         j.at("gyrolocalaxis").get_to(p.GyroscopeYAxis);
+        j.at("gyro_use_separate_aiming_sensitivity").get_to(p.UseSeperateGyroAimSensitivity);
+        j.at("trigger_thresholds").at("lt").get_to(p.TriggerThreshold.x);
+        j.at("trigger_thresholds").at("rt").get_to(p.TriggerThreshold.y);
+        j.at("gyro_aimmode_sensitivity").at("x").get_to(p.GyroscopeAimSensitivity.x);
+        j.at("gyro_aimmode_sensitivity").at("y").get_to(p.GyroscopeAimSensitivity.y);
 
         // Load our button arrays now.
         auto primarybtn_json = j.at("button_primary");
@@ -74,5 +79,9 @@ using namespace js_settings;
                         {"gyrospace", p.GyroscopeSpace},
                         {"gyrolocalaxis", p.GyroscopeYAxis},
                         {"button_primary", p.BUTTONPRIM},
-                        {"button_secondary", p.BUTTONSEC} });
+                        {"button_secondary", p.BUTTONSEC},
+                        {"gyro_use_separate_aiming_sensitivity", p.UseSeperateGyroAimSensitivity},
+                        {"trigger_thresholds", {{"lt", p.TriggerThreshold.x}, {"rt", p.TriggerThreshold.y}}},
+                        {"gyro_aimmode_sensitivity", {{"x", p.GyroscopeAimSensitivity.x}, {"y", p.GyroscopeAimSensitivity.y}}}
+                });
     };

--- a/common/common.cpp
+++ b/common/common.cpp
@@ -41,6 +41,8 @@ using namespace js_settings;
         p.AllowStickInAimMode = j.value("allow_stick_l_aiming", false);
         j.at("freeaim").get_to(p.FreeAiming);
         j.at("aimstick").get_to(p.AimStick);
+        j.at("gyrospace").get_to(p.GyroscopeSpace);
+        j.at("gyrolocalaxis").get_to(p.GyroscopeYAxis);
 
         // Load our button arrays now.
         auto primarybtn_json = j.at("button_primary");
@@ -69,6 +71,8 @@ using namespace js_settings;
                         {"freeaim", p.FreeAiming},
                         {"aimstick", p.AimStick},
                         {"allow_stick_l_aiming", p.AllowStickInAimMode},
+                        {"gyrospace", p.GyroscopeSpace},
+                        {"gyrolocalaxis", p.GyroscopeYAxis},
                         {"button_primary", p.BUTTONPRIM},
                         {"button_secondary", p.BUTTONSEC} });
     };

--- a/common/common.h
+++ b/common/common.h
@@ -33,7 +33,7 @@
 
 #define GYRO_BASEFACTOR 400
 #define PI 3.1415927f
-#define __GYRO_INJECTOR_VERSION__ "v0.3b-prerelease"
+#define __GYRO_INJECTOR_VERSION__ "v0.4b"
 #define __CURRENTYEAR__ "2021"
 
 #define CONSOLE { AllocConsole(); AttachConsole(GetCurrentProcessId()); freopen("CON", "w", stdout; )};

--- a/common/common.h
+++ b/common/common.h
@@ -45,6 +45,7 @@
 #include <utility>
 #include "nlohmann/json.hpp"
 #include "vec2.h"
+#include "vec3.h"
 
 // Bitmask defines for buttons.
 #define GAMEPAD_A 1
@@ -126,6 +127,8 @@ enum STICKMODE {FULLSTICK = 0, XONLY, FLICK, ALLMODES};
 enum PLAYERS { PLAYER1 = 0, PLAYER2, PLAYER3, PLAYER4, ALLPLAYERS};
 enum CONTROLLERMODE { DISCONNECTED = 0, FULLCONTROLLER, JOYCONS };
 enum AIMTYPE { STANDARD = 0, SPLATOON, FREE };
+enum GYROSPACE { LOCALSPACE = 0, PLAYER };
+enum GYROYAXIS { YAW = 0, ROLL, HYBRID };
 
 enum JSD_ControllerType {
     None = 0,
@@ -142,6 +145,22 @@ typedef struct clr {
     unsigned char g;
     unsigned char b;
 } Color;
+
+struct MotionReport {
+    float GyroX = 0.0f;
+    float GyroY = 0.0f;
+    float GyroZ = 0.0f;
+    float AccelX = 0.0f;
+    float AccelY = 0.0f;
+    float AccelZ = 0.0f;
+    float GravX = 0.0f;
+    float GravY = 0.0f;
+    float GravZ = 0.0f;
+    float QuatW = 0.0f;
+    float QuatX = 0.0f;
+    float QuatY = 0.0f;
+    float QuatZ = 0.0f;
+};
 
 namespace js_settings {
 
@@ -175,6 +194,10 @@ namespace js_settings {
         bool AllowStickInAimMode = {false};
         AIMTYPE FreeAiming = { STANDARD };
         bool AimStick = false; // True: Left, False: Right
+        GYROSPACE GyroscopeSpace = LOCALSPACE;
+        GYROYAXIS GyroscopeYAxis = YAW;
+
+
         //vec2<float> VECTORSETTINGS[TOTALVECTORSETTINGS];
         //float FLOATSETTINGS[TOTALVECTORSETTINGS];
         //int SETTINGS[TOTALSETTINGS];
@@ -189,7 +212,9 @@ namespace js_settings {
 
 
 typedef struct {
-    vec2<float> AIMSTICK, GYRO;
+    vec2<float> AIMSTICK;
+    MotionReport MOTION;
+    vec3<float> ACCELEROMETER;
     float LTRIGGER, RTRIGGER;
     int POSX, POSY; // Just in case we want kb/m support
     int BUTTONPRIM[TOTALBUTTONS];

--- a/common/common.h
+++ b/common/common.h
@@ -185,6 +185,9 @@ namespace js_settings {
         vec2<float> MoveStickDeadzone = {0.25, 0.25};
         vec2<float> AimStickSensitivity = {1.00, 1.00};
         vec2<float> GyroscopeSensitivity = {2.00, 2.00};
+        vec2<float> GyroscopeAimSensitivity = {2.00, 2.00};
+        // x = left trigger, y = right trigger
+        vec2<float> TriggerThreshold = {0.5, 0.5};
         float Crosshair = {1.00};
         bool GyroPitchInverted = {false};
         bool StickPitchInverted = {false};
@@ -196,6 +199,7 @@ namespace js_settings {
         bool AimStick = false; // True: Left, False: Right
         GYROSPACE GyroscopeSpace = LOCALSPACE;
         GYROYAXIS GyroscopeYAxis = YAW;
+        bool UseSeperateGyroAimSensitivity = false;
 
 
         //vec2<float> VECTORSETTINGS[TOTALVECTORSETTINGS];
@@ -209,8 +213,6 @@ namespace js_settings {
     void from_json(const nlohmann::json &j, EMUSETTINGS &p);
 }
 
-
-
 typedef struct {
     vec2<float> AIMSTICK;
     MotionReport MOTION;
@@ -221,6 +223,7 @@ typedef struct {
     int BUTTONSEC[TOTALBUTTONS];
     int ARROW[4];
     bool GYROSTATE;
+    vec2<float> GYROSENSITIVITY;
 } DEVICE;
 
 #endif //INC_1964_INPUT_JOYSHOCKCPP_COMMON_H

--- a/common/common.h
+++ b/common/common.h
@@ -173,7 +173,7 @@ namespace js_settings {
 
     typedef struct PROFILE {
         // Secondary devices are used when we are in Joycon mode.
-        enum STICKMODE StickMode = FULLSTICK;
+        enum STICKMODE StickMode = XONLY;
         int DS4Color = 0x000000;
         int BUTTONPRIM[TOTALBUTTONS] = {GAMEPAD_TRIGGER_RIGHT, GAMEPAD_TRIGGER_LEFT, GAMEPAD_LEFTSHOULDER,
                                         GAMEPAD_RIGHTSHOULDER, GAMEPAD_START, GAMEPAD_A, GAMEPAD_B, GAMEPAD_X,

--- a/common/vec2.h
+++ b/common/vec2.h
@@ -118,8 +118,8 @@ public:
         vec2 d(v.x - x, v.y - y);
         return d.length();
     }
-    float length() const {
-        return std::sqrt(x * x + y * y);
+    [[nodiscard]] float length() const {
+        return std::sqrt((x * x) + (y * y));
     }
     void truncate(double length) {
         double angle = atan2f(y, x);

--- a/common/vec3.h
+++ b/common/vec3.h
@@ -1,0 +1,177 @@
+/*
+ * 
+ * Based on vec2.h - copyright below
+Copyright (c) 2020 Chan Jer Shyan
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+* This implementation of vector3 is likely missing some transformations.
+*/
+
+
+
+#ifndef INC_1964_INPUT_JOYSHOCKCPP_VEC3_H
+#define INC_1964_INPUT_JOYSHOCKCPP_VEC3_H
+
+#include <cmath>
+
+
+template <class T>
+class vec3 {
+public:
+    T x, y, z;
+
+    vec3() :x(0), y(0), z(0) {}
+    vec3(T x, T y, T z) : x(x), y(y), z(z) {}
+    vec3(const vec3& v) : x(v.x), y(v.y), z(v.z) {}
+
+    vec3& operator=(const vec3& v) {
+        x = v.x;
+        y = v.y;
+        z = v.z;
+        return *this;
+    }
+
+    vec3 operator+(vec3& v) {
+        return vec3(x + v.x, y + v.y, z + v.z);
+    }
+    vec3 operator-(vec3& v) {
+        return vec3(x - v.x, y - v.y, z - v.z);
+    }
+
+    vec3& operator+=(vec3& v) {
+        x += v.x;
+        y += v.y;
+        z += v.z;
+        return *this;
+    }
+    vec3& operator-=(vec3& v) {
+        x -= v.x;
+        y -= v.y;
+        z -= v.z;
+        return *this;
+    }
+
+    vec3 operator+(double s) {
+        return vec3(x + s, y + s, z + s);
+    }
+
+    vec3 operator-(double s) {
+        return vec3(x - s, y - s, z - s);
+    }
+    vec3 operator*(double s) {
+        return vec3(x * s, y * s, z * s);
+    }
+    vec3 operator/(double s) {
+        return vec3(x / s, y / s, z / s);
+    }
+
+    vec3& operator+=(double s) {
+        x += s;
+        y += s;
+        z += s;
+        return *this;
+    }
+    vec3& operator-=(double s) {
+        x -= s;
+        y -= s;
+        z -= s;
+        return *this;
+    }
+    vec3& operator*=(double s) {
+        x *= s;
+        y *= s;
+        z *= s;
+        return *this;
+    }
+    vec3& operator/=(double s) {
+        x /= s;
+        y /= s;
+        z /= s;
+        return *this;
+    }
+
+    void set(T x, T y, T z) {
+        this->x = x;
+        this->y = y;
+        this->z = z;
+    }
+
+
+
+    vec3& normalize() {
+        if (length() == 0) return *this;
+        *this *= (1.0 / length());
+        return *this;
+    }
+
+    float dist(vec3 v) const {
+        vec3 d(v.x - x, v.y - y, v.z - z);
+        return d.length();
+    }
+    float length() const {
+        return std::sqrt(x * x + y * y + z * z);
+    }
+
+    static float dot(vec3 v1, vec3 v2) {
+        return v1.x * v2.x + v1.y * v2.y + v1.z * v2.z;
+    }
+
+    // https://en.wikipedia.org/wiki/Cross_product#Computing
+    static vec3 cross(vec3 v1, vec3 v2) {
+        return vec3(v1.y * v2.z - v1.z * v2.y,
+                    v1.z * v2.x - v1.x * v2.z,
+                    v1.x * v2.y - v1.y * v2.x);
+    }
+
+    // based off of three dimensional basic rotation tables from Wikipedia: https://en.wikipedia.org/wiki/Rotation_matrix#Basic_rotations
+
+    void rotatex(double deg) {
+        double theta = dev / 180.0 * PI;
+        double c = cos(theta);
+        double s = sin(theta);
+        double ty = y * c - z * s;
+        double tz = y * s + z * c;
+        y = ty;
+        z = tz;
+    }
+
+    void rotatey(double deg) {
+        double theta = dev / 180.0 * PI;
+        double c = cos(theta);
+        double s = sin(theta);
+        double tx = x * c + z * s;
+        double tz = -x * s + z * c;
+        x = tx;
+        z = tz;
+    }
+
+    void rotatez(double deg) {
+        double theta = dev / 180.0 * PI;
+        double c = cos(theta);
+        double s = sin(theta);
+        double tx = x * c - y * s;
+        double ty = x * s + y * c;
+        x = tx;
+        y = tz;
+    }
+
+};
+
+typedef vec3<float> vec3f;
+typedef vec3<double> vec3d;
+
+#endif //INC_1964_INPUT_JOYSHOCKCPP_vec3_H

--- a/game/driver/Goldeneye.cpp
+++ b/game/driver/Goldeneye.cpp
@@ -162,8 +162,8 @@ void Goldeneye::_processOriginalAimmode(int player, const js_settings::PROFILE& 
 
     const float sensitivity_stick_x = profile.AimStickSensitivity.x * sensitivity_basefactor_stick.x / 40.0f; // * fmax(mouseaccel, 1);
     const float sensitivity_stick_y = profile.AimStickSensitivity.y * sensitivity_basefactor_stick.y / 40.0f; // * fmax(mouseaccel, 1);
-    const float sensitivity_gyro_x = profile.GyroscopeSensitivity.x * GYRO_BASEFACTOR / 40.0f; // * fmax(mouseaccel, 1);
-    const float sensitivity_gyro_y = profile.GyroscopeSensitivity.y * GYRO_BASEFACTOR / 40.0f; // * fmax(mouseaccel, 1);
+    const float sensitivity_gyro_x = _cfgptr->Device[player].GYROSENSITIVITY.x * GYRO_BASEFACTOR / 40.0f; // * fmax(mouseaccel, 1);
+    const float sensitivity_gyro_y = _cfgptr->Device[player].GYROSENSITIVITY.y * GYRO_BASEFACTOR / 40.0f; // * fmax(mouseaccel, 1);
 
     const float gunsensitivity_stick_x = sensitivity_stick_x * (profile.Crosshair / 2.5f);
     const float gunsensitivity_stick_y = sensitivity_stick_y * (profile.Crosshair / 2.5f);
@@ -280,8 +280,8 @@ void Goldeneye::_aimmode(const int player, const js_settings::PROFILE& profile, 
                     (profile.AimStickSensitivity.y * (sensitivity_basefactor_stick.y / 2) / sensitivity); // fmax(mouseaccel, 1);
         }
 
-        crosshairposx[player] += gyroscope.y / 10.0f * ((profile.GyroscopeSensitivity.x * GYRO_BASEFACTOR) / sensitivity / RATIOFACTOR) * _cfgptr->DeltaTime; // fmax(mouseaccel, 1);
-        crosshairposy[player] += (!profile.GyroPitchInverted ? gyroscope.x : -gyroscope.x) / 10.0f * ((profile.GyroscopeSensitivity.y * GYRO_BASEFACTOR )/ sensitivity) * _cfgptr->DeltaTime; // fmax(mouseaccel, 1);
+        crosshairposx[player] += gyroscope.y / 10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.x * GYRO_BASEFACTOR) / sensitivity / RATIOFACTOR) * _cfgptr->DeltaTime; // fmax(mouseaccel, 1);
+        crosshairposy[player] += (!profile.GyroPitchInverted ? gyroscope.x : -gyroscope.x) / 10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.y * GYRO_BASEFACTOR )/ sensitivity) * _cfgptr->DeltaTime; // fmax(mouseaccel, 1);
 
         crosshairposx[player] = PluginHelpers::ClampFloat(crosshairposx[player], -CROSSHAIRLIMIT, CROSSHAIRLIMIT); // apply clamp then inject
         crosshairposy[player] = PluginHelpers::ClampFloat(crosshairposy[player], -CROSSHAIRLIMIT, CROSSHAIRLIMIT);
@@ -340,7 +340,7 @@ void Goldeneye::_processFreeAim(int player, const js_settings::PROFILE& profile)
     const float sensitivity_stick_x = profile.AimStickSensitivity.x * sensitivity_basefactor_stick.x / 40.0f; // * fmax(mouseaccel, 1);
     const float sensitivity_stick_y = profile.AimStickSensitivity.y * sensitivity_basefactor_stick.y / 40.0f; // * fmax(mouseaccel, 1);
 
-    const float sensitivity_gyro_yaw_camera = (profile.GyroscopeSensitivity.x * GYRO_BASEFACTOR) / 40.0f; // * fmax(mouseaccel, 1);
+    const float sensitivity_gyro_yaw_camera = (_cfgptr->Device[player].GYROSENSITIVITY.x * GYRO_BASEFACTOR) / 40.0f; // * fmax(mouseaccel, 1);
     const float sensitivity_gyro_yaw = 400 / 40.0f; // * fmax(mouseaccel, 1);
     const float sensitivity_gyro_pitch = 400 / 40.0f; // * fmax(mouseaccel, 1);
 
@@ -479,13 +479,13 @@ void Goldeneye::_aimmode_freeaim(const int player, const js_settings::PROFILE& p
 
     if(profile.FreeAiming == FREE || (profile.FreeAiming == SPLATOON && aimingflag)) {
         crosshairposx[player] += gyroscope.y / 10.0f *
-                                 ((profile.GyroscopeSensitivity.x * GYRO_BASEFACTOR) / sensitivity / RATIOFACTOR) *
+                                 ((_cfgptr->Device[player].GYROSENSITIVITY.x * GYRO_BASEFACTOR) / sensitivity / RATIOFACTOR) *
                                  _cfgptr->DeltaTime; // fmax(mouseaccel, 1);
     }
 
     crosshairposy[player] +=
             (!profile.GyroPitchInverted ? gyroscope.x : -gyroscope.x) /
-            10.0f * ((profile.GyroscopeSensitivity.y * GYRO_BASEFACTOR) / sensitivity) *
+            10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.y * GYRO_BASEFACTOR) / sensitivity) *
             _cfgptr->DeltaTime; // fmax(mouseaccel, 1);
 
     if(profile.FreeAiming == FREE || (profile.FreeAiming == SPLATOON && aimingflag)) {

--- a/game/driver/Goldeneye.cpp
+++ b/game/driver/Goldeneye.cpp
@@ -182,7 +182,7 @@ void Goldeneye::_processOriginalAimmode(int player, const js_settings::PROFILE& 
             if(!cursoraimingflag) { // if not aiming (or geaimmode is off)
                 cam_yaw += aimstickdata.x / 10.0f * sensitivity_stick_x *
                         (fov / basefov); // regular mouselook calculation
-                cam_yaw += gyroscope.y / 10.0f * sensitivity_gyro_x * _cfgptr->DeltaTime * (fov / basefov);
+                cam_yaw += gyroscope.y / 10.0f * sensitivity_gyro_y * _cfgptr->DeltaTime * (fov / basefov);
             }
             else
                 cam_yaw += aimx[player] * (fov / basefov); // scroll screen with aimx/aimy
@@ -226,9 +226,9 @@ void Goldeneye::_processOriginalAimmode(int player, const js_settings::PROFILE& 
             {
                 float gunx = _link->ReadFloat(playerbase[player] + GE_gunx), crosshairx = _link->ReadFloat(playerbase[player] + GE_crosshairx); // after camera x and y have been calculated and injected, calculate the gun/crosshair movement
                 gunx += aimstickdata.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_stick_x * (fov / basefov) * 0.019f;
-                gunx += gyroscope.y / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x * _cfgptr->DeltaTime * (fov / basefov) * 0.019f;
+                gunx += gyroscope.y / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_y * _cfgptr->DeltaTime * (fov / basefov) * 0.019f;
                 crosshairx += aimstickdata.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_stick_x * (fov / 4 / (basefov / 4)) * 0.01912f / RATIOFACTOR;
-                crosshairx += gyroscope.y / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x * (fov / 4 / (basefov / 4)) * _cfgptr->DeltaTime * 0.01912f / RATIOFACTOR;
+                crosshairx += gyroscope.y / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_y * (fov / 4 / (basefov / 4)) * _cfgptr->DeltaTime * 0.01912f / RATIOFACTOR;
                 if(aimingflag) // emulate cursor moving back to the center
                     gunx /= _settings->GetIfEmulatorOverclocked() ? 1.03f : 1.07f, crosshairx /= _settings->GetIfEmulatorOverclocked() ? 1.03f : 1.07f;
                 gunx = PluginHelpers::ClampFloat(gunx, -GUNAIMLIMIT, GUNAIMLIMIT);

--- a/game/driver/Goldeneye.cpp
+++ b/game/driver/Goldeneye.cpp
@@ -41,8 +41,8 @@
 // GOLDENEYE ADDRESSES - OFFSET ADDRESSES BELOW (REQUIRES PLAYERBASE TO USE)
 #define GE_stanceflag 0x800D2FFC - 0x800D2F60
 #define GE_deathflag 0x800D3038 - 0x800D2F60
-#define GE_camx 0x800D30A8 - 0x800D2F60
-#define GE_camy 0x800D30B8 - 0x800D2F60
+#define GE_cam_yaw 0x800D30A8 - 0x800D2F60
+#define GE_cam_pitch 0x800D30B8 - 0x800D2F60
 #define GE_fov 0x800D4124 - 0x800D2F60
 #define GE_crosshairx 0x800D3F50 - 0x800D2F60
 #define GE_crosshairy 0x800D3F54 - 0x800D2F60
@@ -170,25 +170,27 @@ void Goldeneye::_processOriginalAimmode(int player, const js_settings::PROFILE& 
     const float gunsensitivity_gyro_x = sensitivity_gyro_x * (profile.Crosshair / 2.5f);
     const float gunsensitivity_gyro_y = sensitivity_gyro_y * (profile.Crosshair / 2.5f);
 
-    float camx = _link->ReadFloat(playerbase[player] + GE_camx), camy = _link->ReadFloat(playerbase[player] + GE_camy);
-    if(camx >= 0 && camx <= 360 && camy >= -90 && camy <= 90 && fov >= 1 && fov <= FOV_MAX && dead == 0 && watch == 0 && pause == 0 && (camera == 4 || camera == 0) && exit == 1 && menupage == 11 && !mproundend && !mppausemenu) // if safe to inject
+    auto gyroscope = _ihandler.ProcessGyroscopeInputForPlayer((PLAYERS)player);
+
+    float cam_yaw = _link->ReadFloat(playerbase[player] + GE_cam_yaw), cam_pitch = _link->ReadFloat(playerbase[player] + GE_cam_pitch);
+    if(cam_yaw >= 0 && cam_yaw <= 360 && cam_pitch >= -90 && cam_pitch <= 90 && fov >= 1 && fov <= FOV_MAX && dead == 0 && watch == 0 && pause == 0 && (camera == 4 || camera == 0) && exit == 1 && menupage == 11 && !mproundend && !mppausemenu) // if safe to inject
     {
-        _aimmode(player, profile, cursoraimingflag, fov, basefov);
+        _aimmode(player, profile, gyroscope, cursoraimingflag, fov, basefov);
         if(!tankflag) // player is on foot
         {
             _crouch(player, profile); // only allow crouching if player is not in tank
             if(!cursoraimingflag) { // if not aiming (or geaimmode is off)
-                camx += aimstickdata.x / 10.0f * sensitivity_stick_x *
+                cam_yaw += aimstickdata.x / 10.0f * sensitivity_stick_x *
                         (fov / basefov); // regular mouselook calculation
-                camx += _cfgptr->Device[player].GYRO.x / 10.0f * sensitivity_gyro_x * _cfgptr->DeltaTime * (fov / basefov);
+                cam_yaw += gyroscope.y / 10.0f * sensitivity_gyro_x * _cfgptr->DeltaTime * (fov / basefov);
             }
             else
-                camx += aimx[player] * (fov / basefov); // scroll screen with aimx/aimy
-            while(camx < 0)
-                camx += 360;
-            while(camx >= 360)
-                camx -= 360;
-            _link->WriteFloat(playerbase[player] + GE_camx, camx);
+                cam_yaw += aimx[player] * (fov / basefov); // scroll screen with aimx/aimy
+            while(cam_yaw < 0)
+                cam_yaw += 360;
+            while(cam_yaw >= 360)
+                cam_yaw -= 360;
+            _link->WriteFloat(playerbase[player] + GE_cam_yaw, cam_yaw);
         }
         else // player is in tank
         {
@@ -197,7 +199,7 @@ void Goldeneye::_processOriginalAimmode(int player, const js_settings::PROFILE& 
             if(!cursoraimingflag || _link->ReadInt(playerbase[player] + GE_currentweapon) == 32) { // if not aiming (or geaimmode is off) or player is driving tank with tank equipped as weapon, then use regular mouselook calculation
                 tankx += aimstickdata.x / 10.0f * sensitivity_stick_x / (360 / TANKXROTATIONLIMIT * 2.5) *
                          (fov / basefov);
-                tankx += _cfgptr->Device[player].GYRO.x / 10.0f * sensitivity_gyro_x / (360 / TANKXROTATIONLIMIT * 2.5) *
+                tankx += gyroscope.y / 10.0f * sensitivity_gyro_x / (360 / TANKXROTATIONLIMIT * 2.5) *
                          _cfgptr->DeltaTime * (fov / basefov);
             }
             else
@@ -209,24 +211,24 @@ void Goldeneye::_processOriginalAimmode(int player, const js_settings::PROFILE& 
             _link->WriteFloat(GE_tankxrot, tankx);
         }
         if(!cursoraimingflag) {
-            camy += (!profile.StickPitchInverted ? -aimstickdata.y : aimstickdata.y) /
+            cam_pitch += (!profile.StickPitchInverted ? -aimstickdata.y : aimstickdata.y) /
                     10.0f * sensitivity_stick_y * (fov / basefov);
-            camy += (!profile.GyroPitchInverted ? -_cfgptr->Device[player].GYRO.y : _cfgptr->Device[player].GYRO.y) /
+            cam_pitch += (!profile.GyroPitchInverted ? -gyroscope.x : gyroscope.x) /
                     10.0f * sensitivity_gyro_y * _cfgptr->DeltaTime * (fov / basefov);
         }
         else
-            camy += -aimy[player] * (fov / basefov);
-        camy = PluginHelpers::ClampFloat(camy, tankflag ? -20 : -90, 90); // tank limits player from looking down -20
-        _link->WriteFloat(playerbase[player] + GE_camy, camy);
+            cam_pitch += -aimy[player] * (fov / basefov);
+        cam_pitch = PluginHelpers::ClampFloat(cam_pitch, tankflag ? -20 : -90, 90); // tank limits player from looking down -20
+        _link->WriteFloat(playerbase[player] + GE_cam_pitch, cam_pitch);
         if(profile.Crosshair && !cursoraimingflag) // if crosshair movement is enabled and player isn't aiming (don't calculate weapon movement while the player is in aim mode)
         {
             if(!tankflag)
             {
                 float gunx = _link->ReadFloat(playerbase[player] + GE_gunx), crosshairx = _link->ReadFloat(playerbase[player] + GE_crosshairx); // after camera x and y have been calculated and injected, calculate the gun/crosshair movement
                 gunx += aimstickdata.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_stick_x * (fov / basefov) * 0.019f;
-                gunx += _cfgptr->Device[player].GYRO.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x * _cfgptr->DeltaTime * (fov / basefov) * 0.019f;
+                gunx += gyroscope.y / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x * _cfgptr->DeltaTime * (fov / basefov) * 0.019f;
                 crosshairx += aimstickdata.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_stick_x * (fov / 4 / (basefov / 4)) * 0.01912f / RATIOFACTOR;
-                crosshairx += _cfgptr->Device[player].GYRO.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x * (fov / 4 / (basefov / 4)) * _cfgptr->DeltaTime * 0.01912f / RATIOFACTOR;
+                crosshairx += gyroscope.y / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x * (fov / 4 / (basefov / 4)) * _cfgptr->DeltaTime * 0.01912f / RATIOFACTOR;
                 if(aimingflag) // emulate cursor moving back to the center
                     gunx /= _settings->GetIfEmulatorOverclocked() ? 1.03f : 1.07f, crosshairx /= _settings->GetIfEmulatorOverclocked() ? 1.03f : 1.07f;
                 gunx = PluginHelpers::ClampFloat(gunx, -GUNAIMLIMIT, GUNAIMLIMIT);
@@ -234,13 +236,13 @@ void Goldeneye::_processOriginalAimmode(int player, const js_settings::PROFILE& 
                 _link->WriteFloat(playerbase[player] + GE_gunx, gunx);
                 _link->WriteFloat(playerbase[player] + GE_crosshairx, crosshairx);
             }
-            if((!tankflag && camy > -90 || tankflag && camy > -20) && camy < 90) // only allow player's gun to pitch within a valid range
+            if((!tankflag && cam_pitch > -90 || tankflag && cam_pitch > -20) && cam_pitch < 90) // only allow player's gun to pitch within a valid range
             {
                 float guny = _link->ReadFloat(playerbase[player] + GE_guny), crosshairy = _link->ReadFloat(playerbase[player] + GE_crosshairy);
                 guny += (!profile.StickPitchInverted ? aimstickdata.y : -aimstickdata.y) / (!aimingflag ? 40.0f : 20.0f) * gunsensitivity_stick_y * (fov / basefov) * 0.025f;
-                guny += (!profile.GyroPitchInverted ? _cfgptr->Device[player].GYRO.y : -_cfgptr->Device[player].GYRO.y) / (!aimingflag ? 40.0f : 20.0f) * gunsensitivity_gyro_y * _cfgptr->DeltaTime *(fov / basefov) * 0.025f;
+                guny += (!profile.GyroPitchInverted ? gyroscope.x : -gyroscope.x) / (!aimingflag ? 40.0f : 20.0f) * gunsensitivity_gyro_y * _cfgptr->DeltaTime *(fov / basefov) * 0.025f;
                 crosshairy += (!profile.StickPitchInverted ? aimstickdata.y : -aimstickdata.y) / (!aimingflag ? 40.0f : 20.0f) * gunsensitivity_stick_y * (fov / 4 / (basefov / 4)) * 0.0225f;
-                crosshairy += (!profile.GyroPitchInverted ? _cfgptr->Device[player].GYRO.x : -_cfgptr->Device[player].GYRO.y) / (!aimingflag ? 40.0f : 20.0f) * gunsensitivity_gyro_y * _cfgptr->DeltaTime * (fov / 4 / (basefov / 4)) * 0.0225f;
+                crosshairy += (!profile.GyroPitchInverted ? gyroscope.y : -gyroscope.x) / (!aimingflag ? 40.0f : 20.0f) * gunsensitivity_gyro_y * _cfgptr->DeltaTime * (fov / 4 / (basefov / 4)) * 0.0225f;
                 if(aimingflag)
                     guny /= _settings->GetIfEmulatorOverclocked() ? 1.15f : 1.35f, crosshairy /= _settings->GetIfEmulatorOverclocked() ? 1.15f : 1.35f;
                 guny = PluginHelpers::ClampFloat(guny, -GUNAIMLIMIT, GUNAIMLIMIT);
@@ -252,7 +254,7 @@ void Goldeneye::_processOriginalAimmode(int player, const js_settings::PROFILE& 
     }
 }
 
-void Goldeneye::_aimmode(const int player, const js_settings::PROFILE& profile, const int aimingflag, const float fov, const float basefov)
+void Goldeneye::_aimmode(const int player, const js_settings::PROFILE& profile, vec2<float> gyroscope, const int aimingflag, const float fov, const float basefov)
 {
 
     vec2<float> aimstickdata = _ihandler.ProcessAimStickInputForPlayer((PLAYERS)player, true);
@@ -278,8 +280,8 @@ void Goldeneye::_aimmode(const int player, const js_settings::PROFILE& profile, 
                     (profile.AimStickSensitivity.y * (sensitivity_basefactor_stick.y / 2) / sensitivity); // fmax(mouseaccel, 1);
         }
 
-        crosshairposx[player] += _cfgptr->Device[player].GYRO.x / 10.0f * ((profile.GyroscopeSensitivity.x * GYRO_BASEFACTOR) / sensitivity / RATIOFACTOR) * _cfgptr->DeltaTime; // fmax(mouseaccel, 1);
-        crosshairposy[player] += (!profile.GyroPitchInverted ? _cfgptr->Device[player].GYRO.y : -_cfgptr->Device[player].GYRO.y) / 10.0f * ((profile.GyroscopeSensitivity.y * GYRO_BASEFACTOR )/ sensitivity) * _cfgptr->DeltaTime; // fmax(mouseaccel, 1);
+        crosshairposx[player] += gyroscope.y / 10.0f * ((profile.GyroscopeSensitivity.x * GYRO_BASEFACTOR) / sensitivity / RATIOFACTOR) * _cfgptr->DeltaTime; // fmax(mouseaccel, 1);
+        crosshairposy[player] += (!profile.GyroPitchInverted ? gyroscope.x : -gyroscope.x) / 10.0f * ((profile.GyroscopeSensitivity.y * GYRO_BASEFACTOR )/ sensitivity) * _cfgptr->DeltaTime; // fmax(mouseaccel, 1);
 
         crosshairposx[player] = PluginHelpers::ClampFloat(crosshairposx[player], -CROSSHAIRLIMIT, CROSSHAIRLIMIT); // apply clamp then inject
         crosshairposy[player] = PluginHelpers::ClampFloat(crosshairposy[player], -CROSSHAIRLIMIT, CROSSHAIRLIMIT);
@@ -338,19 +340,21 @@ void Goldeneye::_processFreeAim(int player, const js_settings::PROFILE& profile)
     const float sensitivity_stick_x = profile.AimStickSensitivity.x * sensitivity_basefactor_stick.x / 40.0f; // * fmax(mouseaccel, 1);
     const float sensitivity_stick_y = profile.AimStickSensitivity.y * sensitivity_basefactor_stick.y / 40.0f; // * fmax(mouseaccel, 1);
 
-    const float sensitivity_gyro_x_camera = (profile.GyroscopeSensitivity.x * GYRO_BASEFACTOR) / 40.0f; // * fmax(mouseaccel, 1);
-    const float sensitivity_gyro_x = 400 / 40.0f; // * fmax(mouseaccel, 1);
-    const float sensitivity_gyro_y = 400 / 40.0f; // * fmax(mouseaccel, 1);
+    const float sensitivity_gyro_yaw_camera = (profile.GyroscopeSensitivity.x * GYRO_BASEFACTOR) / 40.0f; // * fmax(mouseaccel, 1);
+    const float sensitivity_gyro_yaw = 400 / 40.0f; // * fmax(mouseaccel, 1);
+    const float sensitivity_gyro_pitch = 400 / 40.0f; // * fmax(mouseaccel, 1);
 
     const float gunsensitivity_stick_x = sensitivity_stick_x * (profile.Crosshair / 2.5f);
     const float gunsensitivity_stick_y = sensitivity_stick_y * (profile.Crosshair / 2.5f);
-    const float gunsensitivity_gyro_x = sensitivity_gyro_x_camera * (profile.Crosshair / 2.5f);
-    const float gunsensitivity_gyro_y = sensitivity_gyro_y * (profile.Crosshair / 2.5f);
+    const float gunsensitivity_gyro_yaw = sensitivity_gyro_yaw_camera * (profile.Crosshair / 2.5f);
+    const float gunsensitivity_gyro_pitch = sensitivity_gyro_pitch * (profile.Crosshair / 2.5f);
+    
+    auto gyroscope = _ihandler.ProcessGyroscopeInputForPlayer((PLAYERS)player);
 
-    float camx = _link->ReadFloat(playerbase[player] + GE_camx), camy = _link->ReadFloat(playerbase[player] + GE_camy);
-    if(camx >= 0 && camx <= 360 && camy >= -90 && camy <= 90 && fov >= 1 && fov <= FOV_MAX && dead == 0 && watch == 0 && pause == 0 && (camera == 4 || camera == 0) && exit == 1 && menupage == 11 && !mproundend && !mppausemenu) // if safe to inject
+    float cam_yaw = _link->ReadFloat(playerbase[player] + GE_cam_yaw), cam_pitch = _link->ReadFloat(playerbase[player] + GE_cam_pitch);
+    if(cam_yaw >= 0 && cam_yaw <= 360 && cam_pitch >= -90 && cam_pitch <= 90 && fov >= 1 && fov <= FOV_MAX && dead == 0 && watch == 0 && pause == 0 && (camera == 4 || camera == 0) && exit == 1 && menupage == 11 && !mproundend && !mppausemenu) // if safe to inject
     {
-        _aimmode_freeaim(player, profile, cursoraimingflag, fov, basefov);
+        _aimmode_freeaim(player, profile, gyroscope, cursoraimingflag, fov, basefov);
         if(!tankflag) // player is on foot.
         {
             // there are two classes of free aim mode: Splatoon only allows Y movement, Free Aim allows for X and Y movement.
@@ -358,63 +362,63 @@ void Goldeneye::_processFreeAim(int player, const js_settings::PROFILE& profile)
             // (save for Y, which has a pivot point to allow for better vertical looking)
             _crouch(player, profile); // only allow crouching if player is not in tank
             if(!cursoraimingflag) { // if not aiming (or geaimmode is off)
-                camx += aimstickdata.x / 10.0f * sensitivity_stick_x *
+                cam_yaw += aimstickdata.x / 10.0f * sensitivity_stick_x *
                         (fov / basefov); // regular mouselook calculation
                 if(profile.FreeAiming == SPLATOON) {
-                    camx += _cfgptr->Device[player].GYRO.x / 10.0f * sensitivity_gyro_x_camera * _cfgptr->DeltaTime * (fov / basefov);
+                    cam_yaw += gyroscope.y / 10.0f * sensitivity_gyro_yaw_camera * _cfgptr->DeltaTime * (fov / basefov);
                 }
             }
             else
-                camx += aimx[player] * (fov / basefov); // scroll screen with aimx/aimy
-            while(camx < 0)
-                camx += 360;
-            while(camx >= 360)
-                camx -= 360;
-            _link->WriteFloat(playerbase[player] + GE_camx, camx);
+                cam_yaw += aimx[player] * (fov / basefov); // scroll screen with aimx/aimy
+            while(cam_yaw < 0)
+                cam_yaw += 360;
+            while(cam_yaw >= 360)
+                cam_yaw -= 360;
+            _link->WriteFloat(playerbase[player] + GE_cam_yaw, cam_yaw);
         }
         else // player is in tank
         {
             GE_ResetCrouchToggle(player); // reset crouch toggle if in tank
-            float tankx = _link->ReadFloat(GE_tankxrot);
+            float tank_yaw = _link->ReadFloat(GE_tankxrot);
             if(!cursoraimingflag || _link->ReadInt(playerbase[player] + GE_currentweapon) == 32) { // if not aiming (or geaimmode is off) or player is driving tank with tank equipped as weapon, then use regular mouselook calculation
-                tankx += aimstickdata.x / 10.0f * sensitivity_stick_x / (360 / TANKXROTATIONLIMIT * 2.5) *
-                         (fov / basefov);
+                tank_yaw += aimstickdata.x / 10.0f * sensitivity_stick_x / (360 / TANKXROTATIONLIMIT * 2.5) *
+                            (fov / basefov);
                 if(profile.FreeAiming) {
-                    tankx += _cfgptr->Device[player].GYRO.x / 10.0f * sensitivity_gyro_x_camera / (360 / TANKXROTATIONLIMIT * 2.5) *
-                    _cfgptr->DeltaTime * (fov / basefov);
+                    tank_yaw += gyroscope.y / 10.0f * sensitivity_gyro_yaw_camera / (360 / TANKXROTATIONLIMIT * 2.5) *
+                                _cfgptr->DeltaTime * (fov / basefov);
                 }
             }
             else
-                tankx += aimx[player] / (360 / TANKXROTATIONLIMIT * 2.5) * (fov / basefov);
-            while(tankx < 0)
-                tankx += TANKXROTATIONLIMIT;
-            while(tankx >= TANKXROTATIONLIMIT)
-                tankx -= TANKXROTATIONLIMIT;
-            _link->WriteFloat(GE_tankxrot, tankx);
+                tank_yaw += aimx[player] / (360 / TANKXROTATIONLIMIT * 2.5) * (fov / basefov);
+            while(tank_yaw < 0)
+                tank_yaw += TANKXROTATIONLIMIT;
+            while(tank_yaw >= TANKXROTATIONLIMIT)
+                tank_yaw -= TANKXROTATIONLIMIT;
+            _link->WriteFloat(GE_tankxrot, tank_yaw);
         }
         if(!cursoraimingflag) {
 
-            camy += (!profile.StickPitchInverted ? -aimstickdata.y : aimstickdata.y) /
+            cam_pitch += (!profile.StickPitchInverted ? -aimstickdata.y : aimstickdata.y) /
                     10.0f * sensitivity_stick_y * (fov / basefov);
 
             float crosshairy = _link->ReadFloat(playerbase[player] + GE_crosshairy);
             if(crosshairy > 2 || crosshairy < -2)
-            camy += (!profile.GyroPitchInverted ? -_cfgptr->Device[player].GYRO.y : _cfgptr->Device[player].GYRO.y) /
-                    10.0f * sensitivity_gyro_y * _cfgptr->DeltaTime * (fov / basefov);
+            cam_pitch += (!profile.GyroPitchInverted ? -gyroscope.x : gyroscope.x) /
+                         10.0f * sensitivity_gyro_pitch * _cfgptr->DeltaTime * (fov / basefov);
         }
         else
-            camy += -aimy[player] * (fov / basefov);
-        camy = PluginHelpers::ClampFloat(camy, tankflag ? -20 : -90, 90); // tank limits player from looking down -20
-        _link->WriteFloat(playerbase[player] + GE_camy, camy);
+            cam_pitch += -aimy[player] * (fov / basefov);
+        cam_pitch = PluginHelpers::ClampFloat(cam_pitch, tankflag ? -20 : -90, 90); // tank limits player from looking down -20
+        _link->WriteFloat(playerbase[player] + GE_cam_pitch, cam_pitch);
         if(profile.Crosshair && !cursoraimingflag) // if crosshair movement is enabled and player isn't aiming (don't calculate weapon movement while the player is in aim mode)
         {
             if(!tankflag)
             {
                 float gunx = _link->ReadFloat(playerbase[player] + GE_gunx), crosshairx = _link->ReadFloat(playerbase[player] + GE_crosshairx); // after camera x and y have been calculated and injected, calculate the gun/crosshair movement
                 //gunx += aimstickdata.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_stick_x * (fov / basefov) * 0.019f;
-                gunx += _cfgptr->Device[player].GYRO.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x * _cfgptr->DeltaTime * (fov / basefov) * 0.019f;
+                gunx += gyroscope.y / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_yaw * _cfgptr->DeltaTime * (fov / basefov) * 0.019f;
                 //crosshairx += aimstickdata.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_stick_x * (fov / 4 / (basefov / 4)) * 0.01912f / RATIOFACTOR;
-                crosshairx += _cfgptr->Device[player].GYRO.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x * (fov / 4 / (basefov / 4)) * _cfgptr->DeltaTime * 0.01912f / RATIOFACTOR;
+                crosshairx += gyroscope.y / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_yaw * (fov / 4 / (basefov / 4)) * _cfgptr->DeltaTime * 0.01912f / RATIOFACTOR;
                 if(aimingflag) // emulate cursor moving back to the center
                    gunx /= _settings->GetIfEmulatorOverclocked() ? 1.03f : 1.07f, crosshairx /= _settings->GetIfEmulatorOverclocked() ? 1.03f : 1.07f;
                 gunx = PluginHelpers::ClampFloat(gunx, -GUNAIMLIMITFREE, GUNAIMLIMITFREE);
@@ -422,17 +426,17 @@ void Goldeneye::_processFreeAim(int player, const js_settings::PROFILE& profile)
                 _link->WriteFloat(playerbase[player] + GE_gunx, gunx);
                 _link->WriteFloat(playerbase[player] + GE_crosshairx, crosshairx);
             }
-            if((!tankflag && camy > -90 || tankflag && camy > -20) && camy < 90) // only allow player's gun to pitch within a valid range
+            if((!tankflag && cam_pitch > -90 || tankflag && cam_pitch > -20) && cam_pitch < 90) // only allow player's gun to pitch within a valid range
             {
                 float guny = _link->ReadFloat(playerbase[player] + GE_guny), crosshairy = _link->ReadFloat(playerbase[player] + GE_crosshairy);
                 guny += (!profile.StickPitchInverted ? aimstickdata.y : -aimstickdata.y) / (!aimingflag ? 40.0f : 20.0f) * gunsensitivity_stick_y * (fov / basefov) * 0.025f;
-                guny += (!profile.GyroPitchInverted ? _cfgptr->Device[player].GYRO.y : -_cfgptr->Device[player].GYRO.y) / (!aimingflag ? 40.0f : 20.0f) * gunsensitivity_gyro_y * _cfgptr->DeltaTime * (fov / basefov) * 0.025f;
+                guny += (!profile.GyroPitchInverted ? gyroscope.x : -gyroscope.x) / (!aimingflag ? 40.0f : 20.0f) * gunsensitivity_gyro_pitch * _cfgptr->DeltaTime * (fov / basefov) * 0.025f;
                 crosshairy += (!profile.StickPitchInverted ? aimstickdata.y : -aimstickdata.y) / (!aimingflag ? 40.0f : 20.0f) * gunsensitivity_stick_y * (fov / 4 / (basefov / 4)) * 0.0225f;
-                crosshairy += (!profile.GyroPitchInverted ? _cfgptr->Device[player].GYRO.x : -_cfgptr->Device[player].GYRO.y) / (!aimingflag ? 40.0f : 20.0f) * gunsensitivity_gyro_y * _cfgptr->DeltaTime * (fov / 4 / (basefov / 4)) * 0.0225f;
+                crosshairy += (!profile.GyroPitchInverted ? gyroscope.y : -gyroscope.x) / (!aimingflag ? 40.0f : 20.0f) * gunsensitivity_gyro_pitch * _cfgptr->DeltaTime * (fov / 4 / (basefov / 4)) * 0.0225f;
 
                 if(crosshairy > 45 || crosshairy < -45) {
-                    camy += (!profile.GyroPitchInverted ? -_cfgptr->Device[player].GYRO.y : _cfgptr->Device[player].GYRO.y) /
-                            10.0f * sensitivity_gyro_y * _cfgptr->DeltaTime * (fov / basefov);
+                    cam_pitch += (!profile.GyroPitchInverted ? -gyroscope.x : gyroscope.x) /
+                                 10.0f * sensitivity_gyro_pitch * _cfgptr->DeltaTime * (fov / basefov);
                 }
 
                 if(aimingflag)
@@ -447,7 +451,7 @@ void Goldeneye::_processFreeAim(int player, const js_settings::PROFILE& profile)
     }
 }
 
-void Goldeneye::_aimmode_freeaim(const int player, const js_settings::PROFILE& profile, const int aimingflag, const float fov, const float basefov) {
+void Goldeneye::_aimmode_freeaim(const int player, const js_settings::PROFILE& profile, vec2<float> gyroscope, const int aimingflag, const float fov, const float basefov) {
     const float crosshairx = _link->ReadFloat(playerbase[player] + GE_crosshairx);
     const float crosshairy = _link->ReadFloat(playerbase[player] + GE_crosshairy);
     const float offsetpos[2][33] = {{0, 0, 0, 0, 0.1625, 0.1625, 0.15, 0.5,   0.8, 0.4, 0.5,   0.5,   0.48, 0.9,  0.25, 0.6,  0.6, 0.7, 0.25, 0.15, 0.1625, 0.1625, 0.5,   0.5, 0.9, 0.9, 0, 0, 0, 0, 0, 0.4},
@@ -474,13 +478,13 @@ void Goldeneye::_aimmode_freeaim(const int player, const js_settings::PROFILE& p
     }
 
     if(profile.FreeAiming == FREE || (profile.FreeAiming == SPLATOON && aimingflag)) {
-        crosshairposx[player] += _cfgptr->Device[player].GYRO.x / 10.0f *
+        crosshairposx[player] += gyroscope.y / 10.0f *
                                  ((profile.GyroscopeSensitivity.x * GYRO_BASEFACTOR) / sensitivity / RATIOFACTOR) *
                                  _cfgptr->DeltaTime; // fmax(mouseaccel, 1);
     }
 
     crosshairposy[player] +=
-            (!profile.GyroPitchInverted ? _cfgptr->Device[player].GYRO.y : -_cfgptr->Device[player].GYRO.y) /
+            (!profile.GyroPitchInverted ? gyroscope.x : -gyroscope.x) /
             10.0f * ((profile.GyroscopeSensitivity.y * GYRO_BASEFACTOR) / sensitivity) *
             _cfgptr->DeltaTime; // fmax(mouseaccel, 1);
 
@@ -641,13 +645,13 @@ void Goldeneye::_resetgyro() {
                 _link->WriteFloat(playerbase[player] + GE_crosshairy, 0);
                 _link->WriteFloat(playerbase[player] + GE_gunx, 0);
                 _link->WriteFloat(playerbase[player] + GE_crosshairx, 0);
-                _link->WriteFloat(playerbase[player] + GE_camy, 0);
+                _link->WriteFloat(playerbase[player] + GE_cam_pitch, 0);
             }
             else {
                 // reset aimy, guny, crosshairy to 0, which represents a flat horizontal field of view.
                 _link->WriteFloat(playerbase[player] + GE_guny, 0);
                 _link->WriteFloat(playerbase[player] + GE_crosshairy, 0);
-                _link->WriteFloat(playerbase[player] + GE_camy, 0);
+                _link->WriteFloat(playerbase[player] + GE_cam_pitch, 0);
             }
         }
     }
@@ -658,17 +662,21 @@ void Goldeneye::_processMenu(int player, const js_settings::PROFILE& profile) {
     // Use a constant sensitivity to make the menu feel consistent.
     const float sensitivity_stick_menu_x = 100 / 40.0f;
     const float sensitivity_stick_menu_y = 100 / 40.0f;
-    const float sensitivity_gyro_menu_x = 600 / 40.0f;
-    const float sensitivity_gyro_menu_y = 600 / 40.0f;
+    const float sensitivity_gyro_menu_yaw = 600 / 40.0f;
+    const float sensitivity_gyro_menu_pitch = 600 / 40.0f;
+
+    // Only use standard, yaw local space input for the menus, since we are treating the menu as a cursor.
+    auto gyroscope = _ihandler.GetLocalSpaceInputForPlayer((PLAYERS)player);
+
 
     float menucrosshairx = _link->ReadFloat(GE_menux), menucrosshairy = _link->ReadFloat(GE_menuy);
     // Use a 1:1 sensitivity for the menu to provide a simple and consistent experience.
     auto filtered = _ihandler.HandleDeadZoneStickInput(_cfgptr->Device[player].AIMSTICK,
                                                        profile.AimstickDeadzone);
     menucrosshairx += filtered.x / 10.0f * sensitivity_stick_menu_x * 6;
-    menucrosshairx += _cfgptr->Device[player].GYRO.x / 10.0f * _cfgptr->DeltaTime * sensitivity_gyro_menu_x * 6;
+    menucrosshairx += gyroscope.y / 10.0f * _cfgptr->DeltaTime * sensitivity_gyro_menu_yaw * 6;
     menucrosshairy += filtered.y / 10.0f *  sensitivity_stick_menu_y * (400.0f / 290.0f * 6); // y is a little weaker then x in the menu so add more power to make it feel even with x axis
-    menucrosshairy += _cfgptr->Device[player].GYRO.y / 10.0f * sensitivity_gyro_menu_y * _cfgptr->DeltaTime * (400.0f / 290.0f * 6); // y is a little weaker then x in the menu so add more power to make it feel even with x axis
+    menucrosshairy += gyroscope.x / 10.0f * sensitivity_gyro_menu_pitch * _cfgptr->DeltaTime * (400.0f / 290.0f * 6); // y is a little weaker then x in the menu so add more power to make it feel even with x axis
     menucrosshairx = PluginHelpers::ClampFloat(menucrosshairx, 20, 420);
     menucrosshairy = PluginHelpers::ClampFloat(menucrosshairy, 20, 310);
     _link->WriteFloat(GE_menux, menucrosshairx);

--- a/game/driver/Goldeneye.h
+++ b/game/driver/Goldeneye.h
@@ -34,6 +34,7 @@
 #include "GameDriver.h"
 #include "../../common/Helpers.h"
 #include "../../common/vec2.h"
+#include "../../common/vec3.h"
 #include "../../input/InputHandler.h"
 
 class Goldeneye : public GameDriver {
@@ -49,14 +50,16 @@ private:
     float aimx[4]{};
     float aimy[4]{};
     void _crouch(const int player, const js_settings::PROFILE& profile);
-    void _aimmode(const int player, const js_settings::PROFILE& profile, const int aimingflag, const float fov, const float basefov);
+    void _aimmode(const int player, const js_settings::PROFILE& profile, vec2<float> gyroscope, const int aimingflag, const float fov, const float basefov);
     void _resetgyro();
     void _controller();
     void _injecthacks();
     void _processFreeAim(int player, const js_settings::PROFILE& profile);
-    void _aimmode_freeaim(const int player, const js_settings::PROFILE& profile, const int aimingflag, const float fov, const float basefov);
+    void _aimmode_freeaim(const int player, const js_settings::PROFILE& profile, vec2<float> gyroscope, const int aimingflag, const float fov, const float basefov);
     void _processOriginalAimmode(int player, const js_settings::PROFILE& profile);
     void _processMenu(int player, const js_settings::PROFILE& profile);
+    vec3<float> _processGyroscopeValueBySpace(GYROSPACE space, vec3<float> gyroscope, vec3<float> accelerometer);
+
 
 public:
     explicit Goldeneye(EmulatorLink *linkptr);

--- a/game/driver/PerfectDark.cpp
+++ b/game/driver/PerfectDark.cpp
@@ -241,8 +241,8 @@ void PerfectDark::_aimmode(const int player, const js_settings::PROFILE& profile
             crosshairposx[player] += aimstickdata.x / 10.0f * ((profile.AimStickSensitivity.x * sensitivity_basefactor_stick.x / 2) / sensitivity / RATIOFACTOR); // * fmax(mouseaccel, 1); // calculate the crosshair position
             crosshairposy[player] += (!profile.StickPitchInverted ? aimstickdata.y : -aimstickdata.y) / 10.0f * ((profile.AimStickSensitivity.y * sensitivity_basefactor_stick.y / 2) / sensitivity); // * fmax(mouseaccel, 1);
         }
-        crosshairposx[player] += gyro_vectors.x / 10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.x * GYRO_BASEFACTOR) / (sensitivity) / RATIOFACTOR) * _cfgptr->DeltaTime; //* fmax(mouseaccel, 1); // calculate the crosshair position
-        crosshairposy[player] += (!profile.GyroPitchInverted ? gyro_vectors.y : -gyro_vectors.y) / 10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.y * GYRO_BASEFACTOR) / sensitivity) * _cfgptr->DeltaTime; // * fmax(mouseaccel, 1);
+        crosshairposx[player] += gyro_vectors.y / 10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.x * GYRO_BASEFACTOR) / (sensitivity) / RATIOFACTOR) * _cfgptr->DeltaTime; //* fmax(mouseaccel, 1); // calculate the crosshair position
+        crosshairposy[player] += (!profile.GyroPitchInverted ? gyro_vectors.x : -gyro_vectors.x) / 10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.y * GYRO_BASEFACTOR) / sensitivity) * _cfgptr->DeltaTime; // * fmax(mouseaccel, 1);
         crosshairposx[player] = PluginHelpers::ClampFloat(crosshairposx[player], -CROSSHAIRLIMIT, CROSSHAIRLIMIT); // apply clamp then inject
         crosshairposy[player] = PluginHelpers::ClampFloat(crosshairposy[player], -CROSSHAIRLIMIT, CROSSHAIRLIMIT);
         _link->WriteFloat(playerbase[player] + PD_crosshairx, crosshairposx[player]);
@@ -534,7 +534,7 @@ void PerfectDark::_processOriginalInput(int player, const js_settings::PROFILE& 
                 if(!cursoraimingflag) { // if not aiming (or pdaimmode is off)
                     camx += aimstickdata.x / 10.0f * sensitivity_stick_x *
                             (fov / basefov); // regular mouselook calculation
-                    camx += gyro_vectors.x / 10.0f * sensitivity_gyro_x * _cfgptr->DeltaTime *
+                    camx += gyro_vectors.y / 10.0f * sensitivity_gyro_x * _cfgptr->DeltaTime *
                             (fov / basefov);
                 }
                 else
@@ -551,10 +551,10 @@ void PerfectDark::_processOriginalInput(int player, const js_settings::PROFILE& 
                 float bikeyaw = _link->ReadFloat(bikebase + PD_bikeyaw), bikeroll = _link->ReadFloat(bikebase + PD_bikeroll);
                 if(!cursoraimingflag)
                 {
-                    bikeyaw -= aimstickdata.x / 10.0f * sensitivity_stick_x / (360 / BIKEXROTATIONLIMIT) * (fov / basefov);
-                    bikeyaw -= gyro_vectors.x / 10.0f * sensitivity_gyro_x / (360 / BIKEXROTATIONLIMIT) * _cfgptr->DeltaTime * (fov / basefov);
-                    bikeroll += aimstickdata.x / 10.0f * sensitivity_stick_x * (fov / basefov) / 100;
-                    bikeroll += gyro_vectors.x / 10.0f * sensitivity_gyro_x * (fov / basefov) * _cfgptr->DeltaTime / 100;
+                    bikeyaw -= aimstickdata.y / 10.0f * sensitivity_stick_x / (360 / BIKEXROTATIONLIMIT) * (fov / basefov);
+                    bikeyaw -= gyro_vectors.x / 10.0f * sensitivity_gyro_y / (360 / BIKEXROTATIONLIMIT) * _cfgptr->DeltaTime * (fov / basefov);
+                    bikeroll += aimstickdata.y / 10.0f * sensitivity_stick_x * (fov / basefov) / 100;
+                    bikeroll += gyro_vectors.x / 10.0f * sensitivity_gyro_y * (fov / basefov) * _cfgptr->DeltaTime / 100;
                 }
                 else
                 {
@@ -572,7 +572,7 @@ void PerfectDark::_processOriginalInput(int player, const js_settings::PROFILE& 
             if(!cursoraimingflag) {
                 camy += (!profile.StickPitchInverted ? -aimstickdata.y : aimstickdata.y) /
                         10.0f * sensitivity_stick_x * (fov / basefov);
-                camy += (!profile.GyroPitchInverted ? -gyro_vectors.y : gyro_vectors.y) /
+                camy += (!profile.GyroPitchInverted ? -gyro_vectors.x : gyro_vectors.x) /
                         10.0f * sensitivity_gyro_x * _cfgptr->DeltaTime * (fov / basefov);
             }
             else {
@@ -584,9 +584,9 @@ void PerfectDark::_processOriginalInput(int player, const js_settings::PROFILE& 
             {
                 float gunx = _link->ReadFloat(playerbase[player] + PD_gunrx), crosshairx = _link->ReadFloat(playerbase[player] + PD_crosshairx); // after camera x and y have been calculated and injected, calculate the gun/reload/crosshair movement
                 gunx += aimstickdata.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_stick_x * (fov / basefov) * 0.05f / RATIOFACTOR;
-                gunx += gyro_vectors.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x * _cfgptr->DeltaTime * (fov / basefov) * 0.05f / RATIOFACTOR;
+                gunx += gyro_vectors.y / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x * _cfgptr->DeltaTime * (fov / basefov) * 0.05f / RATIOFACTOR;
                 crosshairx += aimstickdata.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_stick_x * (fov / 4 / (basefov / 4)) * 0.05f / RATIOFACTOR;
-                crosshairx += gyro_vectors.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x * _cfgptr->DeltaTime * (fov / 4 / (basefov / 4)) * 0.05f / RATIOFACTOR;
+                crosshairx += gyro_vectors.y / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x * _cfgptr->DeltaTime * (fov / 4 / (basefov / 4)) * 0.05f / RATIOFACTOR;
                 if(aimingflag) // emulate cursor moving back to the center
                     gunx /= _settings->GetIfEmulatorOverclocked() ? 1.03f : 1.07f, crosshairx /= _settings->GetIfEmulatorOverclocked() ? 1.03f : 1.07f;
                 gunx = PluginHelpers::ClampFloat(gunx, -GUNAIMLIMIT, GUNAIMLIMIT);
@@ -600,10 +600,10 @@ void PerfectDark::_processOriginalInput(int player, const js_settings::PROFILE& 
                 {
                     float guny = _link->ReadFloat(playerbase[player] + PD_gunry), crosshairy = _link->ReadFloat(playerbase[player] + PD_crosshairy);
                     guny += (!profile.StickPitchInverted ? aimstickdata.y : -aimstickdata.y) / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_stick_y * (fov / basefov) * 0.075f;
-                    guny += (!profile.GyroPitchInverted ? gyro_vectors.y : -gyro_vectors.y) / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_y * _cfgptr->DeltaTime * (fov / basefov) * 0.075f;
+                    guny += (!profile.GyroPitchInverted ? gyro_vectors.x : -gyro_vectors.x) / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_y * _cfgptr->DeltaTime * (fov / basefov) * 0.075f;
 
                     crosshairy += (!profile.StickPitchInverted ? aimstickdata.y : -aimstickdata.x) / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_stick_y * (fov / 4 / (basefov / 4)) * 0.1f;
-                    crosshairy += (!profile.GyroPitchInverted ? gyro_vectors.x : -gyro_vectors.x) / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_y * _cfgptr->DeltaTime * (fov / 4 / (basefov / 4)) * 0.1f;
+                    crosshairy += (!profile.GyroPitchInverted ? gyro_vectors.y : -gyro_vectors.y) / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_y * _cfgptr->DeltaTime * (fov / 4 / (basefov / 4)) * 0.1f;
                     if(aimingflag)
                         guny /= _settings->GetIfEmulatorOverclocked() ? 1.15f : 1.35f, crosshairy /= _settings->GetIfEmulatorOverclocked() ? 1.15f : 1.35f;
                     guny = PluginHelpers::ClampFloat(guny, -GUNAIMLIMIT, GUNAIMLIMIT);
@@ -687,7 +687,7 @@ void PerfectDark::_processFreeAimInput(int player, const js_settings::PROFILE& p
                 camx += aimstickdata.x / 10.0f * sensitivity_stick_x * (fov / basefov); // regular mouselook calculation
 
                 if(profile.FreeAiming == SPLATOON) {
-                    camx += gyro_vectors.x / 10.0f * sensitivity_gyro_x * _cfgptr->DeltaTime *
+                    camx += gyro_vectors.y / 10.0f * sensitivity_gyro_x * _cfgptr->DeltaTime *
                             (fov / basefov);
                 }
 
@@ -726,8 +726,8 @@ void PerfectDark::_processFreeAimInput(int player, const js_settings::PROFILE& p
 
             float crosshairy = _link->ReadFloat(playerbase[player] + PD_crosshairy);
             if (crosshairy > 2 || crosshairy < -2) {
-                camy += (!profile.GyroPitchInverted ? -gyro_vectors.y
-                                                : gyro_vectors.y) /
+                camy += (!profile.GyroPitchInverted ? -gyro_vectors.x
+                                                : gyro_vectors.x) /
                         10.0f * sensitivity_gyro_x * _cfgptr->DeltaTime * (fov / basefov);
             }
         } else {
@@ -745,13 +745,13 @@ void PerfectDark::_processFreeAimInput(int player, const js_settings::PROFILE& p
                     PD_crosshairx); // after camera x and y have been calculated and injected, calculate the gun/reload/crosshair movement
             gunx += aimstickdata.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_stick_x * (fov / basefov) * 0.05f /
                     RATIOFACTOR;
-            gunx += gyro_vectors.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x *
+            gunx += gyro_vectors.y / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x *
                     _cfgptr->DeltaTime * (fov / basefov) * 0.05f / RATIOFACTOR;
 
             crosshairx += aimstickdata.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_stick_x *
                           (fov / 4 / (basefov / 4)) * 0.05f / RATIOFACTOR;
 
-            crosshairx += gyro_vectors.x / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x *
+            crosshairx += gyro_vectors.y / (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_x *
                           _cfgptr->DeltaTime * (fov / 4 / (basefov / 4)) * 0.05f / RATIOFACTOR;
 
             if (aimingflag) // emulate cursor moving back to the center
@@ -774,7 +774,7 @@ void PerfectDark::_processFreeAimInput(int player, const js_settings::PROFILE& p
                         playerbase[player] + PD_crosshairy);
                 guny += (!profile.StickPitchInverted ? aimstickdata.y : -aimstickdata.y) / (!aimingflag ? 10.0f : 40.0f) *
                         gunsensitivity_stick_y * (fov / basefov) * 0.075f;
-                guny += (!profile.GyroPitchInverted ? gyro_vectors.y : -gyro_vectors.y) /
+                guny += (!profile.GyroPitchInverted ? gyro_vectors.x : -gyro_vectors.x) /
                         (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_y * _cfgptr->DeltaTime * (fov / basefov) *
                         0.075f;
 
@@ -782,7 +782,7 @@ void PerfectDark::_processFreeAimInput(int player, const js_settings::PROFILE& p
                         (!profile.StickPitchInverted ? aimstickdata.y : -aimstickdata.y) / (!aimingflag ? 10.0f : 40.0f) *
                         gunsensitivity_stick_y * (fov / 4 / (basefov / 4)) * 0.1f;
                 crosshairy +=
-                        (!profile.GyroPitchInverted ? gyro_vectors.y : -gyro_vectors.y) /
+                        (!profile.GyroPitchInverted ? gyro_vectors.x : -gyro_vectors.x) /
                         (!aimingflag ? 10.0f : 40.0f) * gunsensitivity_gyro_y * _cfgptr->DeltaTime *
                         (fov / 4 / (basefov / 4)) * 0.1f;
 
@@ -830,10 +830,10 @@ void PerfectDark::_aimmode_free(const int player, const js_settings::PROFILE& pr
 
     //const float mouseaccel = PROFILE[player].SETTINGS[ACCELERATION] ? sqrt(DEVICE[player].XPOS * DEVICE[player].XPOS + DEVICE[player].YPOS * DEVICE[player].YPOS) / TICKRATE / 12.0f * PROFILE[player].SETTINGS[ACCELERATION] : 0;
     if(profile.FreeAiming == FREE || (profile.FreeAiming == SPLATOON && aimingflag))
-        crosshairposx[player] += gyro_vectors.x / 10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.x * GYRO_BASEFACTOR) / sensitivity / RATIOFACTOR) * _cfgptr->DeltaTime;  // * fmax(mouseaccel, 1); // calculate the crosshair position
+        crosshairposx[player] += gyro_vectors.y / 10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.x * GYRO_BASEFACTOR) / sensitivity / RATIOFACTOR) * _cfgptr->DeltaTime;  // * fmax(mouseaccel, 1); // calculate the crosshair position
 
 
-    crosshairposy[player] += (profile.GyroPitchInverted ? -gyro_vectors.y : gyro_vectors.y) / 10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.y * GYRO_BASEFACTOR) / sensitivity) * _cfgptr->DeltaTime;
+    crosshairposy[player] += (profile.GyroPitchInverted ? -gyro_vectors.x : gyro_vectors.x) / 10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.y * GYRO_BASEFACTOR) / sensitivity) * _cfgptr->DeltaTime;
     if(profile.FreeAiming == FREE || (profile.FreeAiming == SPLATOON && aimingflag))
         crosshairposx[player] = PluginHelpers::ClampFloat(crosshairposx[player], -CROSSHAIRLIMIT, CROSSHAIRLIMIT); // apply clamp then inject
 

--- a/game/driver/PerfectDark.cpp
+++ b/game/driver/PerfectDark.cpp
@@ -241,8 +241,8 @@ void PerfectDark::_aimmode(const int player, const js_settings::PROFILE& profile
             crosshairposx[player] += aimstickdata.x / 10.0f * ((profile.AimStickSensitivity.x * sensitivity_basefactor_stick.x / 2) / sensitivity / RATIOFACTOR); // * fmax(mouseaccel, 1); // calculate the crosshair position
             crosshairposy[player] += (!profile.StickPitchInverted ? aimstickdata.y : -aimstickdata.y) / 10.0f * ((profile.AimStickSensitivity.y * sensitivity_basefactor_stick.y / 2) / sensitivity); // * fmax(mouseaccel, 1);
         }
-        crosshairposx[player] += gyro_vectors.x / 10.0f * ((profile.GyroscopeSensitivity.x * GYRO_BASEFACTOR) / (sensitivity) / RATIOFACTOR) * _cfgptr->DeltaTime; //* fmax(mouseaccel, 1); // calculate the crosshair position
-        crosshairposy[player] += (!profile.GyroPitchInverted ? gyro_vectors.y : -gyro_vectors.y) / 10.0f * ((profile.GyroscopeSensitivity.y * GYRO_BASEFACTOR) / sensitivity) * _cfgptr->DeltaTime; // * fmax(mouseaccel, 1);
+        crosshairposx[player] += gyro_vectors.x / 10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.x * GYRO_BASEFACTOR) / (sensitivity) / RATIOFACTOR) * _cfgptr->DeltaTime; //* fmax(mouseaccel, 1); // calculate the crosshair position
+        crosshairposy[player] += (!profile.GyroPitchInverted ? gyro_vectors.y : -gyro_vectors.y) / 10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.y * GYRO_BASEFACTOR) / sensitivity) * _cfgptr->DeltaTime; // * fmax(mouseaccel, 1);
         crosshairposx[player] = PluginHelpers::ClampFloat(crosshairposx[player], -CROSSHAIRLIMIT, CROSSHAIRLIMIT); // apply clamp then inject
         crosshairposy[player] = PluginHelpers::ClampFloat(crosshairposy[player], -CROSSHAIRLIMIT, CROSSHAIRLIMIT);
         _link->WriteFloat(playerbase[player] + PD_crosshairx, crosshairposx[player]);
@@ -503,8 +503,8 @@ void PerfectDark::_processOriginalInput(int player, const js_settings::PROFILE& 
 
         const float sensitivity_stick_x = profile.AimStickSensitivity.x * sensitivity_basefactor_stick.x / 40.0f; // * fmax(mouseaccel, 1);
         const float sensitivity_stick_y = profile.AimStickSensitivity.y * sensitivity_basefactor_stick.y / 40.0f; // * fmax(mouseaccel, 1);
-        const float sensitivity_gyro_x = (profile.GyroscopeSensitivity.x * GYRO_BASEFACTOR) / 40.0f; // * fmax(mouseaccel, 1);
-        const float sensitivity_gyro_y = (profile.GyroscopeSensitivity.y * GYRO_BASEFACTOR) / 40.0f; // * fmax(mouseaccel, 1);
+        const float sensitivity_gyro_x = (_cfgptr->Device[player].GYROSENSITIVITY.x * GYRO_BASEFACTOR) / 40.0f; // * fmax(mouseaccel, 1);
+        const float sensitivity_gyro_y = (_cfgptr->Device[player].GYROSENSITIVITY.y * GYRO_BASEFACTOR) / 40.0f; // * fmax(mouseaccel, 1);
 
         const float gunsensitivity_stick_x = sensitivity_stick_x * (profile.Crosshair / 2.5f);
         const float gunsensitivity_stick_y = sensitivity_stick_y * (profile.Crosshair / 2.5f);
@@ -649,8 +649,8 @@ void PerfectDark::_processFreeAimInput(int player, const js_settings::PROFILE& p
 
     const float sensitivity_stick_x = profile.AimStickSensitivity.x * sensitivity_basefactor_stick.x / 40.0f; // * fmax(mouseaccel, 1);
     const float sensitivity_stick_y = profile.AimStickSensitivity.y * sensitivity_basefactor_stick.y / 40.0f; // * fmax(mouseaccel, 1);
-    const float sensitivity_gyro_x = (profile.GyroscopeSensitivity.x * GYRO_BASEFACTOR) / 40.0f; // * fmax(mouseaccel, 1);
-    const float sensitivity_gyro_y = (profile.GyroscopeSensitivity.y * GYRO_BASEFACTOR) / 40.0f; // * fmax(mouseaccel, 1);
+    const float sensitivity_gyro_x = (_cfgptr->Device[player].GYROSENSITIVITY.x * GYRO_BASEFACTOR) / 40.0f; // * fmax(mouseaccel, 1);
+    const float sensitivity_gyro_y = (_cfgptr->Device[player].GYROSENSITIVITY.y * GYRO_BASEFACTOR) / 40.0f; // * fmax(mouseaccel, 1);
 
 
     const float gunsensitivity_stick_x = sensitivity_stick_x * (profile.Crosshair / 2.5f);
@@ -830,10 +830,10 @@ void PerfectDark::_aimmode_free(const int player, const js_settings::PROFILE& pr
 
     //const float mouseaccel = PROFILE[player].SETTINGS[ACCELERATION] ? sqrt(DEVICE[player].XPOS * DEVICE[player].XPOS + DEVICE[player].YPOS * DEVICE[player].YPOS) / TICKRATE / 12.0f * PROFILE[player].SETTINGS[ACCELERATION] : 0;
     if(profile.FreeAiming == FREE || (profile.FreeAiming == SPLATOON && aimingflag))
-        crosshairposx[player] += gyro_vectors.x / 10.0f * ((profile.GyroscopeSensitivity.x * GYRO_BASEFACTOR) / sensitivity / RATIOFACTOR) * _cfgptr->DeltaTime;  // * fmax(mouseaccel, 1); // calculate the crosshair position
+        crosshairposx[player] += gyro_vectors.x / 10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.x * GYRO_BASEFACTOR) / sensitivity / RATIOFACTOR) * _cfgptr->DeltaTime;  // * fmax(mouseaccel, 1); // calculate the crosshair position
 
 
-    crosshairposy[player] += (profile.GyroPitchInverted ? -gyro_vectors.y : gyro_vectors.y) / 10.0f * ((profile.GyroscopeSensitivity.y * GYRO_BASEFACTOR) / sensitivity) * _cfgptr->DeltaTime;
+    crosshairposy[player] += (profile.GyroPitchInverted ? -gyro_vectors.y : gyro_vectors.y) / 10.0f * ((_cfgptr->Device[player].GYROSENSITIVITY.y * GYRO_BASEFACTOR) / sensitivity) * _cfgptr->DeltaTime;
     if(profile.FreeAiming == FREE || (profile.FreeAiming == SPLATOON && aimingflag))
         crosshairposx[player] = PluginHelpers::ClampFloat(crosshairposx[player], -CROSSHAIRLIMIT, CROSSHAIRLIMIT); // apply clamp then inject
 

--- a/game/driver/PerfectDark.h
+++ b/game/driver/PerfectDark.h
@@ -66,13 +66,13 @@ private:
     void _crouch(int player, const js_settings::PROFILE& profile);
     void _camspyslayer(int player, const js_settings::PROFILE &profile, int camspyflag, float sensitivityx, float sensitivityy);
     void _processOriginalInput(int player, const js_settings::PROFILE& profile);
-    void _aimmode(int player, const js_settings::PROFILE& profile, int aimingflag, float fov, float basefov);
+    void _aimmode(int player, const js_settings::PROFILE& profile, vec2<float> gyro_vectors, int aimingflag, float fov, float basefov);
     void _radialmenunav(int player, const js_settings::PROFILE& profile);
     void _resetgyro();
     void _controller();
     void _injecthacks();
     void _processFreeAimInput(int player, const js_settings::PROFILE& profile);
-    void _aimmode_free(const int player, const js_settings::PROFILE& profile, const int aimingflag, const float fov, const float basefov);
+    void _aimmode_free(const int player, const js_settings::PROFILE& profile, vec2<float> gyro_vectors, const int aimingflag, const float fov, const float basefov);
 
 public:
     explicit PerfectDark(EmulatorLink* linkptr);

--- a/input/InputHandler.cpp
+++ b/input/InputHandler.cpp
@@ -91,9 +91,9 @@ vec2<float> InputHandler::ProcessGyroscopeInputForPlayer(PLAYERS player) {
         case PLAYER:
             worldYaw = (device.MOTION.GyroY * device.MOTION.GravY) + (device.MOTION.GyroZ * device.MOTION.GravZ);
             yawRelaxFactor = YAWRELAXFACTOR;
-            return vec2<float> {
+             return vec2<float> {
                     -device.MOTION.GyroX,
-                    -(PluginHelpers::sign(worldYaw) * std::min(std::abs(worldYaw) * yawRelaxFactor, vec2f {device.MOTION.GyroY, device.MOTION.GyroZ}.length()))
+                    (PluginHelpers::sign(worldYaw) * std::min(std::abs(worldYaw) * yawRelaxFactor, vec2f {device.MOTION.GyroY, device.MOTION.GyroZ}.length()))
             };
         case LOCALSPACE:
         default:

--- a/input/InputHandler.cpp
+++ b/input/InputHandler.cpp
@@ -26,7 +26,10 @@
 
 
 #include <iostream>
+#include <algorithm>
 #include "InputHandler.h"
+
+#define YAWRELAXFACTOR 1.41f
 
 vec2<float> InputHandler::GetBaseFactorForStickType(enum STICKMODE mode) {
     switch(mode) {
@@ -69,6 +72,48 @@ vec2<float> InputHandler::ProcessAimStickInputForPlayer(PLAYERS player, bool ign
             auto flick = getFlickState(player, _ctrlptr->Device[player].AIMSTICK);
             laststick[player] = _ctrlptr->Device[player].AIMSTICK;
             return { flick, 0 };
+    }
+}
+
+vec2<float> InputHandler::GetLocalSpaceInputForPlayer(PLAYERS player) {
+    auto device = _ctrlptr->Device[player];
+    return vec2<float> { -device.MOTION.GyroX, -device.MOTION.GyroY };
+}
+
+vec2<float> InputHandler::ProcessGyroscopeInputForPlayer(PLAYERS player) {
+    auto device = _ctrlptr->Device[player];
+    auto settings = _settings->GetProfileForPlayer(player);
+    float worldYaw;
+    float yawRelaxFactor;
+    float yawDirection;
+
+    switch(settings.GyroscopeSpace) {
+        case PLAYER:
+            worldYaw = (device.MOTION.GyroY * device.MOTION.GravY) + (device.MOTION.GyroZ * device.MOTION.GravZ);
+            yawRelaxFactor = YAWRELAXFACTOR;
+            return vec2<float> {
+                    -device.MOTION.GyroX,
+                    -(PluginHelpers::sign(worldYaw) * std::min(std::abs(worldYaw) * yawRelaxFactor, vec2f {device.MOTION.GyroY, device.MOTION.GyroZ}.length()))
+            };
+        case LOCALSPACE:
+        default:
+            switch(settings.GyroscopeYAxis) {
+                case YAW:
+                default: // x = pitch, y = yaw
+                    return vec2<float> { -device.MOTION.GyroX, -device.MOTION.GyroY };
+                case ROLL:
+                    return vec2<float> { -device.MOTION.GyroX, -device.MOTION.GyroZ };
+                case HYBRID:
+                    // Basically stolen from Jibb's implementation
+                    vec2<float> yawAxes = { device.MOTION.GyroY, device.MOTION.GyroZ };
+                    if(abs(yawAxes.x) > abs(yawAxes.y)) {
+                        yawDirection = PluginHelpers::sign(yawAxes.x);
+                    }
+                    else {
+                        yawDirection = PluginHelpers::sign(yawAxes.y);
+                    }
+                    return vec2<float> { -device.MOTION.GyroX, -(yawAxes.length() * yawDirection) };
+            }
     }
 }
 
@@ -115,7 +160,7 @@ float InputHandler::getFlickState(PLAYERS player, const vec2<float> &stick) {
 
         float lastFlickProgress = flickprogress[player];
         if (lastFlickProgress < flicktime) {
-            flickprogress[player] = min(flickprogress[player] + _ctrlptr->DeltaTime, flicktime);
+            flickprogress[player] = std::min(flickprogress[player] + _ctrlptr->DeltaTime, flicktime);
 
             // get last time and this time in 0-1 completion range
             float lastPerOne = lastFlickProgress / flicktime;

--- a/input/InputHandler.h
+++ b/input/InputHandler.h
@@ -72,10 +72,13 @@ class InputHandler {
     public:
         InputHandler() = default;
         vec2<float> ProcessAimStickInputForPlayer(PLAYERS player, bool ignore_stickmode);
+        vec2<float> InputHandler::ProcessGyroscopeInputForPlayer(PLAYERS player);
         static vec2<float> HandleDeadZoneStickInput(vec2<float> stick, vec2<float> deadzone);
 
-    static vec2<float> GetBaseFactorForStickType(enum STICKMODE mode);
-    static vec2<float> GetGeneralBaseFactorForStick();
+        static vec2<float> GetBaseFactorForStickType(enum STICKMODE mode);
+        static vec2<float> GetGeneralBaseFactorForStick();
+
+    vec2<float> GetLocalSpaceInputForPlayer(PLAYERS player);
 };
 
 #endif //INC_1964_INPUT_JOYSHOCKCPP_INPUTHANDLER_H

--- a/input/SDLDevice.cpp
+++ b/input/SDLDevice.cpp
@@ -499,11 +499,11 @@ MotionReport SDLDevice::GetCurrentMotionReport(float deltatime) {
     }
     else {
         float accelerometer[3];
-        SDL_GameControllerGetSensorData(_sdlgcptr, SDL_SENSOR_GYRO, &accelerometer[0], 3);
+        SDL_GameControllerGetSensorData(_sdlgcptr, SDL_SENSOR_ACCEL, &accelerometer[0], 3);
 
-        report.AccelX = accelerometer[0];
-        report.AccelY = accelerometer[1];
-        report.AccelZ = accelerometer[2];
+        report.AccelX = accelerometer[0] / 9.8f;
+        report.AccelY = accelerometer[1] / 9.8f;
+        report.AccelZ = accelerometer[2] / 9.8f;
     }
     // It's processing time.
     _gyrocontrol.ProcessMotion(report.GyroX, report.GyroY, report.GyroZ, report.AccelX, report.AccelY, report.AccelZ, deltatime);

--- a/input/SDLDevice.cpp
+++ b/input/SDLDevice.cpp
@@ -2,7 +2,7 @@
 // Created by Robin on 2/4/2021.
 //
 
-#include "InputClasses.h"
+#include "SDLDevice.h"
 
 SDLDevice::SDLDevice(int bindindex) {
         auto test =  SDL_GameControllerTypeForIndex(bindindex);
@@ -32,7 +32,6 @@ SDLDevice::SDLDevice(int bindindex) {
     }
     if(_deviceHasGyroscope) {
         SDL_GameControllerSetSensorEnabled(_sdlgcptr, SDL_SENSOR_GYRO, SDL_TRUE);
-
     }
 }
 
@@ -486,11 +485,11 @@ MotionReport SDLDevice::GetCurrentMotionReport(float deltatime) {
     else {
         // Standard gyroscope supports 3 axis entry: x, y, z
         float gyroscope[3];
-        SDL_GameControllerGetSensorData(_sdlgcptr, SDL_SENSOR_GYRO, gyroscope, 3);
-        // Convert from radians to degrees.
-        report.GyroX = gyroscope[0] * 180 / PI;
-        report.GyroY = gyroscope[1] * 180 / PI;
-        report.GyroZ = gyroscope[2] * 180 / PI;
+        SDL_GameControllerGetSensorData(_sdlgcptr, SDL_SENSOR_GYRO, &gyroscope[0], 3);
+        // Convert from radians to degrees. X = Roll, Y = Pitch, Z = Yaw
+        report.GyroX = gyroscope[0] * (180 / PI);
+        report.GyroY = gyroscope[1] * (180 / PI);
+        report.GyroZ = gyroscope[2] * (180 / PI);
     }
 
     if(!_deviceHasAccelerometer) {
@@ -500,7 +499,7 @@ MotionReport SDLDevice::GetCurrentMotionReport(float deltatime) {
     }
     else {
         float accelerometer[3];
-        SDL_GameControllerGetSensorData(_sdlgcptr, SDL_SENSOR_GYRO, accelerometer, 3);
+        SDL_GameControllerGetSensorData(_sdlgcptr, SDL_SENSOR_GYRO, &accelerometer[0], 3);
 
         report.AccelX = accelerometer[0];
         report.AccelY = accelerometer[1];
@@ -509,6 +508,9 @@ MotionReport SDLDevice::GetCurrentMotionReport(float deltatime) {
     // It's processing time.
     _gyrocontrol.ProcessMotion(report.GyroX, report.GyroY, report.GyroZ, report.AccelX, report.AccelY, report.AccelZ, deltatime);
     _gyrocontrol.GetCalibratedGyro(report.GyroX, report.GyroY, report.GyroZ);
+    _gyrocontrol.GetProcessedAcceleration(report.AccelX, report.AccelY, report.AccelZ);
+    _gyrocontrol.GetGravity(report.GravX, report.GravY, report.GravZ);
+    _gyrocontrol.GetOrientation(report.QuatW, report.QuatX, report.QuatY, report.QuatZ);
 
     return report;
 }

--- a/input/SDLDevice.h
+++ b/input/SDLDevice.h
@@ -16,14 +16,7 @@
 #include "GamepadMotion/GamepadMotion.hpp"
 
 
-struct MotionReport {
-    float GyroX = 0.0f;
-    float GyroY = 0.0f;
-    float GyroZ = 0.0f;
-    float AccelX = 0.0f;
-    float AccelY = 0.0f;
-    float AccelZ = 0.0f;
-};
+
 
 struct AxisReport {
     vec2<float> LStick { 0, 0 };

--- a/input/SdlDriver.cpp
+++ b/input/SdlDriver.cpp
@@ -173,8 +173,8 @@ DWORD SdlDriver::injectionloop() {
             checkwindowtick = 0;
             if(_emulatorwindow != GetForegroundWindow()) // don't send input if the window is inactive.
             {
-                memset(&_cstateptr->Device, 0, sizeof(DEVICE)); // reset player input
-                _gameptr->Inject(); // ship empty input to game
+                //memset(&_cstateptr->Device, 0, sizeof(DEVICE)); // reset player input
+                //gameptr->Inject(); // ship empty input to game
                 _windowactive = 0;
             }
             else {
@@ -185,10 +185,11 @@ DWORD SdlDriver::injectionloop() {
             checkwindowtick++;
 
 
-        if(_windowactive && _gameptr->Status() && !_looppaused) { // if emulator is focused, game is valid and config dialog isn't open
-
+        if(_gameptr->Status() && !_looppaused) { // if emulator is focused, game is valid and config dialog isn't open
+            if(!_windowactive) memset(&_cstateptr->Device, 0, sizeof(DEVICE));
             _gameptr->Inject(); // send input to game driver
         }
+
         Sleep(emutickrate); // 2ms (500 Hz) for overclocked, 4ms (250 Hz) for stock speed
 
     }

--- a/input/SdlDriver.cpp
+++ b/input/SdlDriver.cpp
@@ -136,14 +136,13 @@ DWORD SdlDriver::injectionloop() {
                 sdl_buttons |= 1 << GAMEPAD_OFFSET_TRIGGER_RIGHT;
 
 
-            // Disable the gyro if the toggle is off.
+            // Disable the gyro & accelerometer if the toggle is off.
             if(!gyro_is_disabled[player]) {
-                dev->GYRO.x = -sdl_motionreport.GyroY;
-                dev->GYRO.y = -sdl_motionreport.GyroX;
+                dev->MOTION = sdl_motionreport;
+
             }
             else {
-                dev->GYRO.x = 0;
-                dev->GYRO.y = 0;
+                dev->MOTION = {};
             }
 
             for(int button = FIRE; button < TOTALBUTTONS; button++) {

--- a/input/SdlDriver.cpp
+++ b/input/SdlDriver.cpp
@@ -173,8 +173,8 @@ DWORD SdlDriver::injectionloop() {
             checkwindowtick = 0;
             if(_emulatorwindow != GetForegroundWindow()) // don't send input if the window is inactive.
             {
-                //memset(&_cstateptr->Device, 0, sizeof(DEVICE)); // reset player input
-                //gameptr->Inject(); // ship empty input to game
+                memset(&_cstateptr->Device, 0, sizeof(DEVICE)); // reset player input
+                _gameptr->Inject(); // ship empty input to game
                 _windowactive = 0;
             }
             else {

--- a/input/SdlDriver.h
+++ b/input/SdlDriver.h
@@ -43,7 +43,7 @@
 #include <SDL_hints.h>
 #include <memory>
 #include "../common/common.h"
-#include "InputClasses.h"
+#include "SDLDevice.h"
 #include "../settings/Settings.h"
 #include "../game/Game.h"
 

--- a/settings/Settings.h
+++ b/settings/Settings.h
@@ -32,7 +32,7 @@
 #define INC_1964_INPUT_JOYSHOCKCPP_SETTINGS_H
 
 #include "../common/common.h"
-#include "../input/InputClasses.h"
+#include "../input/SDLDevice.h"
 #include "../plugin.h"
 #include <nlohmann/json.hpp>
 #include <windows.h>

--- a/ui/1964_config.ui
+++ b/ui/1964_config.ui
@@ -507,7 +507,7 @@
         <x>0</x>
         <y>0</y>
         <width>331</width>
-        <height>137</height>
+        <height>192</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="playerSettingsTabGyroLayout">
@@ -523,8 +523,8 @@
        <property name="bottomMargin">
         <number>5</number>
        </property>
-       <item row="2" column="0">
-        <layout class="QHBoxLayout" name="playerSettingsTabGyroYAxisSensitivityLayout">
+       <item row="1" column="0">
+        <layout class="QHBoxLayout" name="playerSettingsTabGyroGyroSpaceLayout">
          <property name="leftMargin">
           <number>10</number>
          </property>
@@ -532,59 +532,89 @@
           <number>10</number>
          </property>
          <item>
-          <widget class="QLabel" name="playerSettingsTabGyroYAxisSensitivityLabel">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sensitivity for Gyroscope Y Axis.&lt;/p&gt;&lt;p&gt;Measured in Degrees (°). Sensitivity controls how many degrees of real world movement translate into game movement.&lt;/p&gt;&lt;p&gt;Example: A sensitivity of 1.00° will translate every 1.00° of real world movement into 1.00° of game movement. A sensitivity of 2.00 will translate every 1.00° of real world movement into 2.00° of game movement.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <widget class="QLabel" name="playerSettingsTabGyroGyroSpaceLabel">
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
            </property>
            <property name="text">
-            <string>Y-Axis Sensitivity</string>
+            <string>Gyroscope Space</string>
            </property>
-           <property name="wordWrap">
-            <bool>true</bool>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QSlider" name="playerSettingsTabGyroYAxisSensitivitySlider">
-           <property name="minimum">
-            <number>50</number>
-           </property>
-           <property name="maximum">
-            <number>2000</number>
-           </property>
-           <property name="value">
-            <number>100</number>
-           </property>
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-           </property>
-           <property name="tickPosition">
-            <enum>QSlider::TicksBelow</enum>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QDoubleSpinBox" name="playerSettingsTabGyroYAxisSensitivitySpinbox">
-           <property name="suffix">
-            <string>°</string>
-           </property>
-           <property name="minimum">
-            <double>0.500000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>20.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.010000000000000</double>
-           </property>
-           <property name="value">
-            <double>1.000000000000000</double>
-           </property>
+          <widget class="QComboBox" name="playerSettingsTabGyroGyroSpaceBox">
+           <item>
+            <property name="text">
+             <string>Local</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Player</string>
+            </property>
+           </item>
           </widget>
          </item>
         </layout>
        </item>
-       <item row="3" column="0">
+       <item row="0" column="0">
+        <layout class="QHBoxLayout" name="playerSettingsTabGyroAimingStyleLayout">
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <property name="rightMargin">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="playerSettingsTabGyroAimingStyleLabel">
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gyroscope crosshair aiming mode. Note that using anything other then &lt;span style=&quot; font-weight:600;&quot;&gt;Standard&lt;/span&gt; can cause bugs.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Standard: &lt;/span&gt;Standard mouselook style aiming. Gyroscope controls camera, crosshair is fixed to center of screen.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Splatoon: &lt;/span&gt;Simulates Splatoon style reticle/crosshair aiming. Gyroscope will move unfixed crosshair on Y axis - X Axis is fixed outside of aim mode.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Free: &lt;/span&gt;Fully unlocked reticle/crosshair aiming. Gyroscope will move crosshair on X and Y axis even when Aim Mode is not enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Aiming Style</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="playerSettingsTabGyroAimingStyleBox">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gyroscope crosshair aiming mode. Note that using anything other then &lt;span style=&quot; font-weight:600;&quot;&gt;Standard&lt;/span&gt; can cause bugs.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Standard: &lt;/span&gt;Standard mouselook style aiming. Gyroscope controls camera, crosshair is fixed to center of screen.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Splatoon: &lt;/span&gt;Simulates Splatoon style reticle/crosshair aiming. Gyroscope will move unfixed crosshair on Y axis - X Axis is fixed outside of aim mode.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Free: &lt;/span&gt;Fully unlocked reticle/crosshair aiming. Gyroscope will move crosshair on X and Y axis even when Aim Mode is not enabled. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <item>
+            <property name="text">
+             <string>Standard</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Splatoon</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Free Aim</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="5" column="0">
         <layout class="QHBoxLayout" name="playerSettingsTabGyroCheckRow1Layout">
          <property name="leftMargin">
           <number>10</number>
@@ -621,7 +651,49 @@
          </item>
         </layout>
        </item>
-       <item row="1" column="0">
+       <item row="2" column="0">
+        <layout class="QHBoxLayout" name="playerSettingsTabGyroLocalSpaceYAxisLayout">
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <property name="rightMargin">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="playerSettingsTabGyroLocalSpaceYAxisLabel">
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Vertical Axis (Local)</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="playerSettingsTabGyroLocalSpaceYAxisBox">
+           <item>
+            <property name="text">
+             <string>Yaw</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Roll</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Hybrid</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="3" column="0">
         <layout class="QHBoxLayout" name="playerSettingsTabGyroXAxisSensitivityLayout">
          <property name="leftMargin">
           <number>10</number>
@@ -635,7 +707,7 @@
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sensitivity for Gyroscope X Axis.&lt;/p&gt;&lt;p&gt;Measured in Degrees (°). Sensitivity controls how many degrees of real world movement translate into game movement.&lt;/p&gt;&lt;p&gt;Example: A sensitivity of 1.00° will translate every 1.00° of real world movement into 1.00° of game movement. A sensitivity of 2.00 will translate every 1.00° of real world movement into 2.00° of game movement.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
-            <string>X-Axis Sensitivity</string>
+            <string>Yaw (X) Sensitivity</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -688,8 +760,8 @@
          </item>
         </layout>
        </item>
-       <item row="0" column="0">
-        <layout class="QHBoxLayout" name="playerSettingsTabGyroAimingStyleLayout">
+       <item row="4" column="0">
+        <layout class="QHBoxLayout" name="playerSettingsTabGyroYAxisSensitivityLayout">
          <property name="leftMargin">
           <number>10</number>
          </property>
@@ -697,44 +769,54 @@
           <number>10</number>
          </property>
          <item>
-          <widget class="QLabel" name="playerSettingsTabGyroAimingStyleLabel">
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
+          <widget class="QLabel" name="playerSettingsTabGyroYAxisSensitivityLabel">
            <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gyroscope crosshair aiming mode. Note that using anything other then &lt;span style=&quot; font-weight:600;&quot;&gt;Standard&lt;/span&gt; can cause bugs.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Standard: &lt;/span&gt;Standard mouselook style aiming. Gyroscope controls camera, crosshair is fixed to center of screen.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Splatoon: &lt;/span&gt;Simulates Splatoon style reticle/crosshair aiming. Gyroscope will move unfixed crosshair on Y axis - X Axis is fixed outside of aim mode.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Free: &lt;/span&gt;Fully unlocked reticle/crosshair aiming. Gyroscope will move crosshair on X and Y axis even when Aim Mode is not enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sensitivity for Gyroscope Y Axis.&lt;/p&gt;&lt;p&gt;Measured in Degrees (°). Sensitivity controls how many degrees of real world movement translate into game movement.&lt;/p&gt;&lt;p&gt;Example: A sensitivity of 1.00° will translate every 1.00° of real world movement into 1.00° of game movement. A sensitivity of 2.00 will translate every 1.00° of real world movement into 2.00° of game movement.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
-            <string>Aiming Style</string>
+            <string>Pitch (Y) Sensitivity</string>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
+           <property name="wordWrap">
+            <bool>true</bool>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QComboBox" name="playerSettingsTabGyroAimingStyleBox">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Gyroscope crosshair aiming mode. Note that using anything other then &lt;span style=&quot; font-weight:600;&quot;&gt;Standard&lt;/span&gt; can cause bugs.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Standard: &lt;/span&gt;Standard mouselook style aiming. Gyroscope controls camera, crosshair is fixed to center of screen.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Splatoon: &lt;/span&gt;Simulates Splatoon style reticle/crosshair aiming. Gyroscope will move unfixed crosshair on Y axis - X Axis is fixed outside of aim mode.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Free: &lt;/span&gt;Fully unlocked reticle/crosshair aiming. Gyroscope will move crosshair on X and Y axis even when Aim Mode is not enabled. &lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          <widget class="QSlider" name="playerSettingsTabGyroYAxisSensitivitySlider">
+           <property name="minimum">
+            <number>50</number>
            </property>
-           <item>
-            <property name="text">
-             <string>Standard</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Splatoon</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Free Aim</string>
-            </property>
-           </item>
+           <property name="maximum">
+            <number>2000</number>
+           </property>
+           <property name="value">
+            <number>100</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="tickPosition">
+            <enum>QSlider::TicksBelow</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="playerSettingsTabGyroYAxisSensitivitySpinbox">
+           <property name="suffix">
+            <string>°</string>
+           </property>
+           <property name="minimum">
+            <double>0.500000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>20.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+           <property name="value">
+            <double>1.000000000000000</double>
+           </property>
           </widget>
          </item>
         </layout>
@@ -1566,11 +1648,23 @@
      <rect>
       <x>0</x>
       <y>20</y>
-      <width>351</width>
-      <height>159</height>
+      <width>361</width>
+      <height>171</height>
      </rect>
     </property>
     <layout class="QVBoxLayout" name="globalLayout">
+     <property name="leftMargin">
+      <number>5</number>
+     </property>
+     <property name="topMargin">
+      <number>2</number>
+     </property>
+     <property name="rightMargin">
+      <number>5</number>
+     </property>
+     <property name="bottomMargin">
+      <number>2</number>
+     </property>
      <item>
       <layout class="QHBoxLayout" name="globalRatioLayout">
        <item>

--- a/ui/1964_config.ui
+++ b/ui/1964_config.ui
@@ -271,8 +271,8 @@
     <rect>
      <x>10</x>
      <y>50</y>
-     <width>381</width>
-     <height>61</height>
+     <width>399</width>
+     <height>69</height>
     </rect>
    </property>
    <layout class="QFormLayout" name="controllerSettingsLayout">
@@ -507,7 +507,7 @@
         <x>0</x>
         <y>0</y>
         <width>331</width>
-        <height>192</height>
+        <height>338</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="playerSettingsTabGyroLayout">
@@ -523,46 +523,6 @@
        <property name="bottomMargin">
         <number>5</number>
        </property>
-       <item row="1" column="0">
-        <layout class="QHBoxLayout" name="playerSettingsTabGyroGyroSpaceLayout">
-         <property name="leftMargin">
-          <number>10</number>
-         </property>
-         <property name="rightMargin">
-          <number>10</number>
-         </property>
-         <item>
-          <widget class="QLabel" name="playerSettingsTabGyroGyroSpaceLabel">
-           <property name="maximumSize">
-            <size>
-             <width>100</width>
-             <height>16777215</height>
-            </size>
-           </property>
-           <property name="text">
-            <string>Gyroscope Space</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QComboBox" name="playerSettingsTabGyroGyroSpaceBox">
-           <item>
-            <property name="text">
-             <string>Local</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Player</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </item>
        <item row="0" column="0">
         <layout class="QHBoxLayout" name="playerSettingsTabGyroAimingStyleLayout">
          <property name="leftMargin">
@@ -668,7 +628,10 @@
             </size>
            </property>
            <property name="text">
-            <string>Vertical Axis (Local)</string>
+            <string>Pitch Axis</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
            </property>
           </widget>
          </item>
@@ -707,7 +670,7 @@
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sensitivity for Gyroscope X Axis.&lt;/p&gt;&lt;p&gt;Measured in Degrees (°). Sensitivity controls how many degrees of real world movement translate into game movement.&lt;/p&gt;&lt;p&gt;Example: A sensitivity of 1.00° will translate every 1.00° of real world movement into 1.00° of game movement. A sensitivity of 2.00 will translate every 1.00° of real world movement into 2.00° of game movement.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
-            <string>Yaw (X) Sensitivity</string>
+            <string>Horiz. Sensitivity</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -717,7 +680,7 @@
          <item>
           <widget class="QSlider" name="playerSettingsTabGyroXAxisSensitivitySlider">
            <property name="minimum">
-            <number>50</number>
+            <number>0</number>
            </property>
            <property name="maximum">
             <number>2000</number>
@@ -745,7 +708,7 @@
             <string>°</string>
            </property>
            <property name="minimum">
-            <double>0.500000000000000</double>
+            <double>0.000000000000000</double>
            </property>
            <property name="maximum">
             <double>20.000000000000000</double>
@@ -774,7 +737,7 @@
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sensitivity for Gyroscope Y Axis.&lt;/p&gt;&lt;p&gt;Measured in Degrees (°). Sensitivity controls how many degrees of real world movement translate into game movement.&lt;/p&gt;&lt;p&gt;Example: A sensitivity of 1.00° will translate every 1.00° of real world movement into 1.00° of game movement. A sensitivity of 2.00 will translate every 1.00° of real world movement into 2.00° of game movement.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
-            <string>Pitch (Y) Sensitivity</string>
+            <string>Vertical Sensitivity</string>
            </property>
            <property name="wordWrap">
             <bool>true</bool>
@@ -784,7 +747,7 @@
          <item>
           <widget class="QSlider" name="playerSettingsTabGyroYAxisSensitivitySlider">
            <property name="minimum">
-            <number>50</number>
+            <number>0</number>
            </property>
            <property name="maximum">
             <number>2000</number>
@@ -806,7 +769,7 @@
             <string>°</string>
            </property>
            <property name="minimum">
-            <double>0.500000000000000</double>
+            <double>0.000000000000000</double>
            </property>
            <property name="maximum">
             <double>20.000000000000000</double>
@@ -816,6 +779,197 @@
            </property>
            <property name="value">
             <double>1.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="6" column="0">
+        <layout class="QHBoxLayout" name="playerSettingsTabGyroUseSeperateAimSensCheckboxLayout">
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <property name="rightMargin">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QCheckBox" name="playerSettingsTabGyroUseSeperateAimSensCheckbox">
+           <property name="text">
+            <string>Use Seperate Aim Mode Sensitivity</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="1" column="0">
+        <layout class="QHBoxLayout" name="playerSettingsTabGyroGyroSpaceLayout">
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <property name="rightMargin">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="playerSettingsTabGyroGyroSpaceLabel">
+           <property name="maximumSize">
+            <size>
+             <width>100</width>
+             <height>16777215</height>
+            </size>
+           </property>
+           <property name="text">
+            <string>Space</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="playerSettingsTabGyroGyroSpaceBox">
+           <item>
+            <property name="text">
+             <string>Local</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Player</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="7" column="0">
+        <layout class="QHBoxLayout" name="playerSettingsTabGyroXAxisSensitivityAimLayout">
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <property name="rightMargin">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="playerSettingsTabGyroXAxisSensitivityAimLabel">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sensitivity for Gyroscope X Axis.&lt;/p&gt;&lt;p&gt;Measured in Degrees (°). Sensitivity controls how many degrees of real world movement translate into game movement.&lt;/p&gt;&lt;p&gt;Example: A sensitivity of 1.00° will translate every 1.00° of real world movement into 1.00° of game movement. A sensitivity of 2.00 will translate every 1.00° of real world movement into 2.00° of game movement.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Aim Pitch (X) Sens</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSlider" name="playerSettingsTabGyroXAxisSensitivityAimSlider">
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>2000</number>
+           </property>
+           <property name="sliderPosition">
+            <number>100</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="tickPosition">
+            <enum>QSlider::TicksBelow</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="playerSettingsTabGyroXAxisSensitivityAimSpinbox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>8</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="suffix">
+            <string>°</string>
+           </property>
+           <property name="minimum">
+            <double>0.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>20.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+           <property name="value">
+            <double>1.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item row="8" column="0">
+        <layout class="QHBoxLayout" name="playerSettingsTabGyroYAxisSensitivityAimLayout">
+         <property name="leftMargin">
+          <number>10</number>
+         </property>
+         <property name="rightMargin">
+          <number>10</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="playerSettingsTabGyroYAxisSensitivityAimLabel">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sensitivity for Gyroscope X Axis.&lt;/p&gt;&lt;p&gt;Measured in Degrees (°). Sensitivity controls how many degrees of real world movement translate into game movement.&lt;/p&gt;&lt;p&gt;Example: A sensitivity of 1.00° will translate every 1.00° of real world movement into 1.00° of game movement. A sensitivity of 2.00 will translate every 1.00° of real world movement into 2.00° of game movement.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Aim Yaw (Y) Sens  </string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QSlider" name="playerSettingsTabGyroYAxisSensitivityAimSlider">
+           <property name="minimum">
+            <number>0</number>
+           </property>
+           <property name="maximum">
+            <number>2000</number>
+           </property>
+           <property name="sliderPosition">
+            <number>100</number>
+           </property>
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="tickPosition">
+            <enum>QSlider::TicksBelow</enum>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDoubleSpinBox" name="playerSettingsTabGyroYAxisSensitivityAimSpinbox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>8</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="suffix">
+            <string>°</string>
+           </property>
+           <property name="minimum">
+            <double>0.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>20.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.010000000000000</double>
+           </property>
+           <property name="value">
+            <double>0.000000000000000</double>
            </property>
           </widget>
          </item>
@@ -1483,7 +1637,7 @@
         <x>10</x>
         <y>10</y>
         <width>321</width>
-        <height>125</height>
+        <height>183</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="playerSettingsTabOtherLayout">
@@ -1624,6 +1778,52 @@
            </item>
           </layout>
          </item>
+         <item>
+          <layout class="QHBoxLayout" name="playerSettingsTabOtherTriggerThreshold">
+           <item>
+            <widget class="QLabel" name="playerSettingsTabOtherTriggerThresholdLabel">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets the relative amount of distance an analog trigger must be pulled before it registers as a button press.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This value is only useful for controllers that have analog triggers, such as Sony or Xbox controllers&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Default: 0.50 (50% Pull)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Trigger Thresholds</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QDoubleSpinBox" name="playerSettingsTabOtherTriggerThresholdL">
+             <property name="prefix">
+              <string>L: </string>
+             </property>
+             <property name="minimum">
+              <double>0.100000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.010000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QDoubleSpinBox" name="playerSettingsTabOtherTriggerThresholdR">
+             <property name="prefix">
+              <string>R: </string>
+             </property>
+             <property name="minimum">
+              <double>0.100000000000000</double>
+             </property>
+             <property name="maximum">
+              <double>1.000000000000000</double>
+             </property>
+             <property name="singleStep">
+              <double>0.010000000000000</double>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
         </layout>
        </item>
       </layout>
@@ -1649,7 +1849,7 @@
       <x>0</x>
       <y>20</y>
       <width>361</width>
-      <height>171</height>
+      <height>177</height>
      </rect>
     </property>
     <layout class="QVBoxLayout" name="globalLayout">

--- a/ui/ConfigDialog.cpp
+++ b/ui/ConfigDialog.cpp
@@ -147,6 +147,7 @@ void ConfigDialog::_loadProfileSettingsIntoUi(const js_settings::PROFILE profile
     _baseDialog->playerSettingsTabOtherCursorAimingPerfectDarkCheckbox->setChecked(profile.PerfectDarkAimMode);
     _baseDialog->playerSettingsTabOtherCursorAimingGoldeneyeCheckbox->setChecked(profile.GoldeneyeAimMode);
     _baseDialog->playerSettingsTabOtherAllowAimingUsingStickCheckbox->setChecked(profile.AllowStickInAimMode);
+    _baseDialog->playerSettingsTabGyroUseSeperateAimSensCheckbox->setChecked(profile.UseSeperateGyroAimSensitivity);
 
     auto ds4color = _getColorFromInt(profile.DS4Color);
     _baseDialog->playerSettingsTabOtherDS4SpinboxRed->setValue(ds4color.r);
@@ -184,6 +185,16 @@ void ConfigDialog::_loadProfileSettingsIntoUi(const js_settings::PROFILE profile
 
     _baseDialog->playerSettingsTabStickMoveDeadzoneYSpinbox->setValue(profile.MoveStickDeadzone.y);
     _baseDialog->playerSettingsTabStickMoveDeadzoneYSlider->setValue(profile.MoveStickDeadzone.y * 100);
+
+    _baseDialog->playerSettingsTabGyroXAxisSensitivityAimSpinbox->setValue(profile.GyroscopeAimSensitivity.x);
+    _baseDialog->playerSettingsTabGyroXAxisSensitivityAimSlider->setValue(profile.GyroscopeAimSensitivity.x * 100);
+
+    _baseDialog->playerSettingsTabGyroYAxisSensitivityAimSpinbox->setValue(profile.GyroscopeAimSensitivity.y);
+    _baseDialog->playerSettingsTabGyroYAxisSensitivityAimSlider->setValue(profile.GyroscopeAimSensitivity.y * 100);
+
+    _baseDialog->playerSettingsTabOtherTriggerThresholdL->setValue(profile.TriggerThreshold.x * 100);
+    _baseDialog->playerSettingsTabOtherTriggerThresholdR->setValue(profile.TriggerThreshold.y * 100);
+
 
 }
 
@@ -776,6 +787,38 @@ void ConfigDialog::on_playerSettingsTabOtherDS4SpinboxBlue_valueChanged(int valu
 
 }
 
+void ConfigDialog::on_playerSettingsTabGyroUseSeperateAimSensCheckbox_stateChanged(int state) {
+    _localprofiles[_selectedplayer].UseSeperateGyroAimSensitivity = (bool)state;
+}
+
+void ConfigDialog::on_playerSettingsTabGyroYAxisSensitivityAimSpinbox_valueChanged(double value) {
+    _baseDialog->playerSettingsTabGyroYAxisSensitivityAimSlider->setValue((int)(value * 100.0));
+    _localprofiles[_selectedplayer].GyroscopeAimSensitivity.y = (float)value;
+}
+
+void ConfigDialog::on_playerSettingsTabGyroXAxisSensitivityAimSpinbox_valueChanged(double value) {
+    _baseDialog->playerSettingsTabGyroXAxisSensitivityAimSlider->setValue((int)(value * 100.0));
+    _localprofiles[_selectedplayer].GyroscopeAimSensitivity.x = (float)value;
+}
+
+void ConfigDialog::on_playerSettingsTabGyroXAxisSensitivityAimSlider_sliderMoved(int value) {
+    _baseDialog->playerSettingsTabGyroXAxisSensitivityAimSpinbox->setValue(value / 100.0);
+    _localprofiles[_selectedplayer].GyroscopeAimSensitivity.x = ((float)value / 100.0f);
+}
+
+void ConfigDialog::on_playerSettingsTabGyroYAxisSensitivityAimSlider_sliderMoved(int value) {
+    _baseDialog->playerSettingsTabGyroYAxisSensitivityAimSpinbox->setValue(value / 100.0);
+    _localprofiles[_selectedplayer].GyroscopeAimSensitivity.y = ((float)value / 100.0f);
+}
+
+void ConfigDialog::on_playerSettingsTabOtherTriggerThresholdL_valueChanged(double value) {
+    _localprofiles[_selectedplayer].TriggerThreshold.x = (float)value;
+}
+
+void ConfigDialog::on_playerSettingsTabOtherTriggerThresholdR_valueChanged(double value) {
+    _localprofiles[_selectedplayer].TriggerThreshold.y = (float)value;
+}
+
 // ---------------------------------------------------------------------------------------------------------
 
 void ConfigDialog::_commitAssignments() {
@@ -864,3 +907,5 @@ void ConfigDialog::_mapButtonToCommand(CONTROLLERENUM command, bool isSecondary)
     buttonlist[command]->setText(
             QString::fromStdString("None"));
 }
+
+

--- a/ui/ConfigDialog.cpp
+++ b/ui/ConfigDialog.cpp
@@ -153,6 +153,12 @@ void ConfigDialog::_loadProfileSettingsIntoUi(const js_settings::PROFILE profile
     _baseDialog->playerSettingsTabOtherDS4SpinboxGreen->setValue(ds4color.g);
     _baseDialog->playerSettingsTabOtherDS4SpinboxBlue->setValue(ds4color.b);
 
+    _baseDialog->playerSettingsTabGyroGyroSpaceBox->setCurrentIndex(profile.GyroscopeSpace);
+    _baseDialog->playerSettingsTabGyroLocalSpaceYAxisBox->setCurrentIndex(profile.GyroscopeSpace);
+
+    if(_baseDialog->playerSettingsTabGyroGyroSpaceBox->currentIndex() != (int)LOCALSPACE)
+        _baseDialog->playerSettingsTabGyroLocalSpaceYAxisBox->setEnabled(false);
+
     //auto colorrole = _baseDialog->colorwidget.
 
     _baseDialog->playerSettingsTabGyroXAxisSensitivitySpinbox->setValue(profile.GyroscopeSensitivity.x);
@@ -639,6 +645,34 @@ void ConfigDialog::on_playerSettingsTabStickAimStickModeBox_activated(int index)
             break;
         case FLICK:
             _localprofiles[_selectedplayer].StickMode = FLICK;
+            break;
+    }
+}
+
+void ConfigDialog::on_playerSettingsTabGyroLocalSpaceYAxisBox_activated(int index) {
+    switch((GYROYAXIS)index) {
+        default:
+        case YAW:
+            _localprofiles[_selectedplayer].GyroscopeYAxis = YAW;
+            break;
+        case ROLL:
+            _localprofiles[_selectedplayer].GyroscopeYAxis = ROLL;
+            break;
+        case HYBRID:
+            _localprofiles[_selectedplayer].GyroscopeYAxis = HYBRID;
+            break;
+    }
+}
+void ConfigDialog::on_playerSettingsTabGyroGyroSpaceBox_activated(int index) {
+    switch((GYROSPACE)index) {
+        default:
+        case LOCALSPACE:
+            _localprofiles[_selectedplayer].GyroscopeSpace = LOCALSPACE;
+            _baseDialog->playerSettingsTabGyroLocalSpaceYAxisBox->setDisabled(false);
+            break;
+        case PLAYER:
+            _localprofiles[_selectedplayer].GyroscopeSpace = PLAYER;
+            _baseDialog->playerSettingsTabGyroLocalSpaceYAxisBox->setDisabled(true);
             break;
     }
 }

--- a/ui/ConfigDialog.cpp
+++ b/ui/ConfigDialog.cpp
@@ -155,7 +155,7 @@ void ConfigDialog::_loadProfileSettingsIntoUi(const js_settings::PROFILE profile
     _baseDialog->playerSettingsTabOtherDS4SpinboxBlue->setValue(ds4color.b);
 
     _baseDialog->playerSettingsTabGyroGyroSpaceBox->setCurrentIndex(profile.GyroscopeSpace);
-    _baseDialog->playerSettingsTabGyroLocalSpaceYAxisBox->setCurrentIndex(profile.GyroscopeSpace);
+    _baseDialog->playerSettingsTabGyroLocalSpaceYAxisBox->setCurrentIndex(profile.GyroscopeYAxis);
 
     if(_baseDialog->playerSettingsTabGyroGyroSpaceBox->currentIndex() != (int)LOCALSPACE)
         _baseDialog->playerSettingsTabGyroLocalSpaceYAxisBox->setEnabled(false);

--- a/ui/ConfigDialog.h
+++ b/ui/ConfigDialog.h
@@ -140,6 +140,14 @@ private slots:
     void on_playerSettingsTabOtherDS4SpinboxRed_valueChanged(int value);
     void on_playerSettingsTabOtherDS4SpinboxGreen_valueChanged(int value);
     void on_playerSettingsTabOtherDS4SpinboxBlue_valueChanged(int value);
+    void on_playerSettingsTabGyroUseSeperateAimSensCheckbox_stateChanged(int state);
+    void on_playerSettingsTabGyroXAxisSensitivityAimSpinbox_valueChanged(double value);
+    void on_playerSettingsTabGyroYAxisSensitivityAimSpinbox_valueChanged(double value);
+    void on_playerSettingsTabGyroXAxisSensitivityAimSlider_sliderMoved(int value);
+    void on_playerSettingsTabGyroYAxisSensitivityAimSlider_sliderMoved(int value);
+    void on_playerSettingsTabOtherTriggerThresholdL_valueChanged(double value);
+    void on_playerSettingsTabOtherTriggerThresholdR_valueChanged(double value);
+
 
 
 

--- a/ui/ConfigDialog.h
+++ b/ui/ConfigDialog.h
@@ -104,6 +104,10 @@ private slots:
     void on_cancelButton_clicked();
     void on_okButton_clicked();
     void on_reconnectControllers_clicked();
+    void on_playerSettingsTabGyroLocalSpaceYAxisBox_activated(int index);
+    void on_playerSettingsTabGyroGyroSpaceBox_activated(int index);
+
+
     void on_playerSettingsTabGyroXAxisSensitivitySlider_sliderMoved(int value);
     void on_playerSettingsTabGyroXAxisSensitivitySpinbox_valueChanged(double value);
     void on_playerSettingsTabGyroYAxisSensitivitySlider_sliderMoved(int value);


### PR DESCRIPTION
This will add three new features to the plugin:

- Gyroscope Player Space Support (See [Jibb Smart's Blog Entry on Player Space](http://gyrowiki.jibbsmart.com/blog:player-space-gyro-and-alternatives-explained
- Ability to choose yaw axis between standard pivot, roll, or hybrid.
- Trigger Thresholds (Ability to set how far you pull the analog trigger before a 'press' is registered.)
- Ability to set a separate sensitivity for Aiming Mode.

These features are the mainstay for v4.0b.